### PR TITLE
fix(gc): accept raw protobuf field names as aliases

### DIFF
--- a/SKYNET server/Services/GameCoordinator/GameCoordinatorProtoCodec.cs
+++ b/SKYNET server/Services/GameCoordinator/GameCoordinatorProtoCodec.cs
@@ -683,7 +683,19 @@ public sealed class GameCoordinatorProtoCodec
             property.Name,
             SnakeToCamel(property.Name)
         };
-        return aliases.Distinct(StringComparer.Ordinal).ToList();
+
+        // Preserve the exact protobuf field name as a valid TypeScript alias.
+        var protoName =
+            property.GetCustomAttribute<ProtoMemberAttribute>()?.Name;
+
+        if (!string.IsNullOrWhiteSpace(protoName))
+        {
+            aliases.Add(protoName);
+        }
+
+        return aliases
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
     }
 
     private static string SnakeToCamel(string value)


### PR DESCRIPTION
`GameCoordinatorProtoCodec` currently rejects canonical protobuf field names declared via `ProtoMemberAttribute.Name`, even though those names are valid and commonly used by AppID-aware GC implementations.

This change adds the raw `ProtoMemberAttribute.Name` to `GetFieldAliases()` while preserving all existing aliases.

Verified with (AppID 1422450):

- 9164 → 9165
- 9271 → 9272
- 9280 → 9281

Before the fix, these routes failed with `Unknown field`; after the fix, they encode successfully.

Build verified with:
`dotnet build "SKYNET server\SKYNET server.csproj" -c Debug`