### PR TITLE
Expand legacy x86 game and payload-shadow control

### DIFF
--- a/SKYNET Injector Helper/Program.cs
+++ b/SKYNET Injector Helper/Program.cs
@@ -1,0 +1,170 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace SKYNET.InjectorHelper;
+
+internal static class Program
+{
+    private static int Main(string[] args)
+    {
+        try
+        {
+            if (args.Length != 4)
+                throw new ArgumentException("Expected four base64-encoded arguments: exe, DLL, command line, working directory.");
+            if (IntPtr.Size != 4)
+                throw new InvalidOperationException("The x86 injector helper is not running as a 32-bit process.");
+
+            var exePath = Decode(args[0]);
+            var dllPath = Decode(args[1]);
+            var arguments = Decode(args[2]);
+            var workingDirectory = Decode(args[3]);
+            var processId = LaunchAndInject(exePath, dllPath, arguments, workingDirectory);
+            Console.Out.WriteLine($"OK {processId}");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(ex.ToString());
+            return 1;
+        }
+    }
+
+    private static string Decode(string value)
+    {
+        if (string.IsNullOrEmpty(value) || value[0] != 'B')
+            throw new FormatException("The injector helper received an invalid encoded argument.");
+
+        return Encoding.UTF8.GetString(Convert.FromBase64String(value.Substring(1)));
+    }
+
+    private static uint LaunchAndInject(string exePath, string dllPath, string arguments, string workingDirectory)
+    {
+        if (!File.Exists(exePath)) throw new FileNotFoundException("Executable not found", exePath);
+        if (!File.Exists(dllPath)) throw new FileNotFoundException("Injection DLL not found", dllPath);
+
+        var startupInfo = new STARTUPINFO
+        {
+            cb = Marshal.SizeOf<STARTUPINFO>(),
+            dwFlags = STARTF_USESHOWWINDOW,
+            wShowWindow = SW_SHOWNORMAL
+        };
+        var commandLineText = $"\"{exePath}\" {arguments}".Trim();
+        var commandLine = new StringBuilder(commandLineText, Math.Max(commandLineText.Length + 1, 260));
+        if (!CreateProcess(exePath, commandLine, IntPtr.Zero, IntPtr.Zero, false, CREATE_SUSPENDED,
+                IntPtr.Zero, workingDirectory, ref startupInfo, out var processInfo))
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "CreateProcess failed in the x86 injector helper");
+
+        try
+        {
+            Inject(processInfo.hProcess, dllPath);
+            AllowSetForegroundWindow(processInfo.dwProcessId);
+            if (ResumeThread(processInfo.hThread) == unchecked((uint)-1))
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "ResumeThread failed in the x86 injector helper");
+            return processInfo.dwProcessId;
+        }
+        catch
+        {
+            TerminateProcess(processInfo.hProcess, 1);
+            throw;
+        }
+        finally
+        {
+            if (processInfo.hThread != IntPtr.Zero) CloseHandle(processInfo.hThread);
+            if (processInfo.hProcess != IntPtr.Zero) CloseHandle(processInfo.hProcess);
+        }
+    }
+
+    private static void Inject(IntPtr processHandle, string dllPath)
+    {
+        var kernel = GetModuleHandle("kernel32.dll");
+        var loadLibrary = GetProcAddress(kernel, "LoadLibraryW");
+        if (loadLibrary == IntPtr.Zero)
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "GetProcAddress(LoadLibraryW) failed in the x86 injector helper");
+
+        var pathBytes = Encoding.Unicode.GetBytes(Path.GetFullPath(dllPath) + "\0");
+        var remotePath = VirtualAllocEx(processHandle, IntPtr.Zero, (uint)pathBytes.Length, MEM_COMMIT_RESERVE, PAGE_READWRITE);
+        if (remotePath == IntPtr.Zero)
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "VirtualAllocEx failed in the x86 injector helper");
+
+        try
+        {
+            if (!WriteProcessMemory(processHandle, remotePath, pathBytes, (uint)pathBytes.Length, out var written) ||
+                written.ToInt64() != pathBytes.Length)
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "WriteProcessMemory failed in the x86 injector helper");
+
+            var thread = CreateRemoteThread(processHandle, IntPtr.Zero, 0, loadLibrary, remotePath, 0, out _);
+            if (thread == IntPtr.Zero)
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "CreateRemoteThread failed in the x86 injector helper");
+
+            try
+            {
+                var wait = WaitForSingleObject(thread, INJECTION_TIMEOUT_MS);
+                if (wait == WAIT_TIMEOUT)
+                    throw new TimeoutException("Timed out while loading the x86 payload into the target process.");
+                if (wait != WAIT_OBJECT_0)
+                    throw new Win32Exception(Marshal.GetLastWin32Error(), $"Waiting for the x86 injection thread failed (wait=0x{wait:X8})");
+                if (!GetExitCodeThread(thread, out var moduleHandle) || moduleHandle == 0)
+                    throw new InvalidOperationException("LoadLibraryW in the x86 target returned NULL (injection failed).");
+            }
+            finally
+            {
+                CloseHandle(thread);
+            }
+        }
+        finally
+        {
+            VirtualFreeEx(processHandle, remotePath, 0, MEM_RELEASE);
+        }
+    }
+
+    private const uint CREATE_SUSPENDED = 0x00000004;
+    private const uint MEM_COMMIT_RESERVE = 0x3000;
+    private const uint MEM_RELEASE = 0x8000;
+    private const uint PAGE_READWRITE = 0x04;
+    private const uint WAIT_OBJECT_0 = 0;
+    private const uint WAIT_TIMEOUT = 0x00000102;
+    private const uint INJECTION_TIMEOUT_MS = 15000;
+    private const int STARTF_USESHOWWINDOW = 0x00000001;
+    private const short SW_SHOWNORMAL = 1;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PROCESS_INFORMATION
+    {
+        public IntPtr hProcess;
+        public IntPtr hThread;
+        public uint dwProcessId;
+        public uint dwThreadId;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct STARTUPINFO
+    {
+        public int cb;
+        public string? lpReserved;
+        public string? lpDesktop;
+        public string? lpTitle;
+        public int dwX, dwY, dwXSize, dwYSize, dwXCountChars, dwYCountChars, dwFillAttribute, dwFlags;
+        public short wShowWindow, cbReserved2;
+        public IntPtr lpReserved2, hStdInput, hStdOutput, hStdError;
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern bool CreateProcess(string lpApplicationName, StringBuilder lpCommandLine,
+        IntPtr lpProcessAttributes, IntPtr lpThreadAttributes, bool bInheritHandles, uint dwCreationFlags,
+        IntPtr lpEnvironment, string lpCurrentDirectory, ref STARTUPINFO lpStartupInfo, out PROCESS_INFORMATION lpProcessInformation);
+
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern uint ResumeThread(IntPtr hThread);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool TerminateProcess(IntPtr hProcess, uint exitCode);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern IntPtr VirtualAllocEx(IntPtr hProcess, IntPtr address, uint size, uint allocationType, uint protect);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool VirtualFreeEx(IntPtr hProcess, IntPtr address, uint size, uint freeType);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool WriteProcessMemory(IntPtr hProcess, IntPtr address, byte[] buffer, uint size, out IntPtr written);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern IntPtr CreateRemoteThread(IntPtr hProcess, IntPtr attributes, uint stackSize, IntPtr startAddress, IntPtr parameter, uint flags, out uint threadId);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern uint WaitForSingleObject(IntPtr handle, uint milliseconds);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool GetExitCodeThread(IntPtr thread, out uint exitCode);
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Ansi)] private static extern IntPtr GetProcAddress(IntPtr module, string name);
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)] private static extern IntPtr GetModuleHandle(string moduleName);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool CloseHandle(IntPtr handle);
+    [DllImport("user32.dll", SetLastError = true)] private static extern bool AllowSetForegroundWindow(uint processId);
+}

--- a/SKYNET Injector Helper/SKYNET Injector Helper.csproj
+++ b/SKYNET Injector Helper/SKYNET Injector Helper.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <PlatformTarget>x86</PlatformTarget>
+    <Prefer32Bit>true</Prefer32Bit>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <AssemblyName>SKYNET Injector Helper</AssemblyName>
+    <RootNamespace>SKYNET.InjectorHelper</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/SKYNET Steam Client/App.xaml.cs
+++ b/SKYNET Steam Client/App.xaml.cs
@@ -242,7 +242,7 @@ public partial class App : Application
         {
             var path = Path.Combine(directory, "steam_appid.txt");
             return File.Exists(path) &&
-                   uint.TryParse(File.ReadAllText(path).Trim(), out var appId)
+                   uint.TryParse(File.ReadAllText(path).Trim('\0', ' ', '\t', '\r', '\n'), out var appId)
                 ? appId
                 : 0;
         }

--- a/SKYNET Steam Client/MainWindow.xaml.cs
+++ b/SKYNET Steam Client/MainWindow.xaml.cs
@@ -421,7 +421,7 @@ public partial class MainWindow : Window
         try
         {
             var txt = Path.Combine(Path.GetDirectoryName(exePath) ?? "", "steam_appid.txt");
-            if (File.Exists(txt) && uint.TryParse(File.ReadAllText(txt).Trim(), out var id)) return id;
+            if (File.Exists(txt) && uint.TryParse(File.ReadAllText(txt).Trim('\0', ' ', '\t', '\r', '\n'), out var id)) return id;
         }
         catch { }
         return 0;

--- a/SKYNET Steam Client/SKYNET Steam Client.csproj
+++ b/SKYNET Steam Client/SKYNET Steam Client.csproj
@@ -31,6 +31,22 @@
     <Using Include="System.IO" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\SKYNET Injector Helper\SKYNET Injector Helper.csproj"
+                      ReferenceOutputAssembly="false" />
+    <Content Include="..\SKYNET Injector Helper\bin\$(Configuration)\net472\SKYNET Injector Helper.exe">
+      <Link>helpers\x86\SKYNET Injector Helper.exe</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Include="..\SKYNET Injector Helper\bin\$(Configuration)\net472\SKYNET Injector Helper.exe.config"
+             Condition="Exists('..\SKYNET Injector Helper\bin\$(Configuration)\net472\SKYNET Injector Helper.exe.config')">
+      <Link>helpers\x86\SKYNET Injector Helper.exe.config</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
   <!-- The emulator DLLs shipped as the injection payload. Copied next to the exe. -->
   <ItemGroup>
     <Content Include="payload\**">

--- a/SKYNET Steam Client/Services/DllInjector.cs
+++ b/SKYNET Steam Client/Services/DllInjector.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
+using SKYNET.Client.Models;
 
 namespace SKYNET.Client.Services;
 
@@ -34,6 +35,21 @@ public static class DllInjector
         if (!File.Exists(exePath)) throw new FileNotFoundException("Executable not found", exePath);
         if (!File.Exists(dllPath)) throw new FileNotFoundException("Injection DLL not found", dllPath);
 
+        var targetArch = PeArch.Detect(exePath);
+        var payloadArch = PeArch.Detect(dllPath);
+        if (targetArch == GameArch.Unknown)
+            throw new InvalidOperationException($"Could not determine the architecture of '{exePath}'.");
+        if (payloadArch == GameArch.Unknown)
+            throw new InvalidOperationException($"Could not determine the architecture of '{dllPath}'.");
+        if (targetArch != payloadArch)
+            throw new InvalidOperationException($"Payload architecture {payloadArch} does not match target architecture {targetArch}.");
+        if (targetArch == GameArch.X64 && IntPtr.Size != 8)
+            throw new InvalidOperationException("An x64 game requires the launcher to run as a 64-bit process.");
+
+        var rebindsStaticImport = !string.IsNullOrWhiteSpace(staticImportModuleName);
+        if (targetArch == GameArch.X86 && IntPtr.Size == 8 && !rebindsStaticImport)
+            return LaunchThroughX86Helper(exePath, dllPath, arguments, workingDir);
+
         var si = new STARTUPINFO
         {
             cb = Marshal.SizeOf<STARTUPINFO>(),
@@ -47,7 +63,6 @@ public static class DllInjector
         var cmd = new StringBuilder(cmdLine, Math.Max(cmdLine.Length + 1, 260));
 
         const uint CREATE_SUSPENDED = 0x00000004;
-        var rebindsStaticImport = !string.IsNullOrWhiteSpace(staticImportModuleName);
         var creationFlags = CREATE_SUSPENDED;
         if (!CreateProcess(exePath, cmd, IntPtr.Zero, IntPtr.Zero, false,
                 creationFlags, IntPtr.Zero, workingDir, ref si, out pi))
@@ -86,12 +101,70 @@ public static class DllInjector
         }
     }
 
+    private static Process LaunchThroughX86Helper(
+        string exePath,
+        string dllPath,
+        string arguments,
+        string workingDir)
+    {
+        var helperPath = Path.Combine(AppContext.BaseDirectory, "helpers", "x86", "SKYNET Injector Helper.exe");
+        if (!File.Exists(helperPath))
+            throw new FileNotFoundException("The x86 injector helper is missing", helperPath);
+
+        // Prefix the payload so an empty string is still a non-empty command-line
+        // argument. Without this, games with no launch arguments shift argv and the
+        // x86 helper receives only three values instead of four.
+        static string Encode(string value) => "B" + Convert.ToBase64String(Encoding.UTF8.GetBytes(value ?? string.Empty));
+        var helperArguments = string.Join(" ", new[]
+        {
+            Encode(Path.GetFullPath(exePath)),
+            Encode(Path.GetFullPath(dllPath)),
+            Encode(arguments),
+            Encode(workingDir)
+        });
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = helperPath,
+            Arguments = helperArguments,
+            WorkingDirectory = AppContext.BaseDirectory,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        using var helper = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Could not start the x86 injector helper.");
+        var standardOutputTask = helper.StandardOutput.ReadToEndAsync();
+        var standardErrorTask = helper.StandardError.ReadToEndAsync();
+        if (!helper.WaitForExit(30000))
+        {
+            try { helper.Kill(); } catch { }
+            throw new TimeoutException("The x86 injector helper did not finish within 30 seconds.");
+        }
+
+        var standardOutput = standardOutputTask.GetAwaiter().GetResult();
+        var standardError = standardErrorTask.GetAwaiter().GetResult();
+        var result = standardOutput.Trim();
+        if (helper.ExitCode != 0 || !result.StartsWith("OK ", StringComparison.Ordinal) ||
+            !uint.TryParse(result.Substring(3), out var processId))
+        {
+            var detail = string.IsNullOrWhiteSpace(standardError) ? result : standardError.Trim();
+            throw new InvalidOperationException($"The x86 injector helper failed:{Environment.NewLine}{detail}");
+        }
+
+        AllowSetForegroundWindow(processId);
+        return Process.GetProcessById((int)processId);
+    }
+
     private static void InjectInto(IntPtr hProcess, string dllPath)
     {
-        // kernel32 (and thus LoadLibraryW) sits at the same address in every process
-        // of the session, so our local address is valid in the remote process.
-        IntPtr hKernel = GetModuleHandle("kernel32.dll");
-        IntPtr loadLibrary = GetProcAddress(hKernel, "LoadLibraryW");
+        // Matching-architecture system DLLs share their mapping within the Windows
+        // session, including before a CREATE_SUSPENDED target has initialized enough
+        // for module enumeration. Cross-architecture x86 launches are delegated to
+        // the matching x86 helper before this method is reached.
+        var kernel = GetModuleHandle("kernel32.dll");
+        var loadLibrary = GetProcAddress(kernel, "LoadLibraryW");
         if (loadLibrary == IntPtr.Zero)
             throw new Win32Exception(Marshal.GetLastWin32Error(), "GetProcAddress(LoadLibraryW) failed");
 

--- a/SKYNET Steam Client/Services/GameLauncher.cs
+++ b/SKYNET Steam Client/Services/GameLauncher.cs
@@ -40,6 +40,7 @@ public sealed class GameLauncher
 {
     private const string BackupSuffix = ".skynet-orig";
     private const string MarkerSuffix = ".skynet-injected";
+    private const int PreviousPayloadShadowsToKeep = 3;
 
     private static string PayloadDll(GameArch arch)
     {
@@ -56,7 +57,10 @@ public sealed class GameLauncher
         if (!game.ExeExists)
             return LaunchResult.Fail($"Executable not found:\n{game.ExecutablePath}");
 
-        var arch = game.Arch != GameArch.Unknown ? game.Arch : PeArch.Detect(game.ExecutablePath);
+        // The PE header is authoritative. A stale/manual architecture selection
+        // must never make us inject an x86 DLL into an x64 executable (or vice versa).
+        var detectedArch = PeArch.Detect(game.ExecutablePath);
+        var arch = detectedArch != GameArch.Unknown ? detectedArch : game.Arch;
         if (arch == GameArch.Unknown)
             return LaunchResult.Fail("Could not determine game architecture (x86/x64).");
 
@@ -116,7 +120,7 @@ public sealed class GameLauncher
         if (string.IsNullOrWhiteSpace(arguments))
             return false;
 
-        return arguments
+        return arguments!
             .Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
             .Any(argument => string.Equals(argument, expected, StringComparison.OrdinalIgnoreCase));
     }
@@ -131,12 +135,32 @@ public sealed class GameLauncher
         var shadowPath = Path.Combine(shadowDir, payloadFileName);
 
         Directory.CreateDirectory(shadowDir);
-        if (!File.Exists(shadowPath) || new FileInfo(shadowPath).Length != payloadBytes.Length)
+        bool shadowMatches = false;
+        try
+        {
+            shadowMatches = File.Exists(shadowPath) &&
+                File.ReadAllBytes(shadowPath).SequenceEqual(payloadBytes);
+        }
+        catch
+        {
+            // A missing, unreadable, or partially replaced shadow must be rebuilt
+            // from the payload shipped next to this launcher.
+        }
+
+        if (!shadowMatches)
         {
             File.WriteAllBytes(shadowPath, payloadBytes);
         }
 
-        CleanupPayloadShadows(shadowRoot, hash);
+        try
+        {
+            Directory.SetLastWriteTimeUtc(shadowDir, DateTime.UtcNow);
+        }
+        catch
+        {
+        }
+
+        CleanupPayloadShadows(shadowRoot, hash, payloadFileName);
         return shadowPath;
     }
 
@@ -144,10 +168,10 @@ public sealed class GameLauncher
     {
         using var sha256 = SHA256.Create();
         var hashBytes = sha256.ComputeHash(payloadBytes);
-        return BitConverter.ToString(hashBytes, 0, 8).Replace("-", string.Empty).ToLowerInvariant();
+        return BitConverter.ToString(hashBytes).Replace("-", string.Empty).ToLowerInvariant();
     }
 
-    private static void CleanupPayloadShadows(string shadowRoot, string activeHash)
+    private static void CleanupPayloadShadows(string shadowRoot, string activeHash, string payloadFileName)
     {
         try
         {
@@ -156,14 +180,17 @@ public sealed class GameLauncher
                 return;
             }
 
-            foreach (var directory in Directory.GetDirectories(shadowRoot))
-            {
-                if (string.Equals(Path.GetFileName(directory), activeHash, StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
+            var shadows = Directory.GetDirectories(shadowRoot)
+                .Where(directory => File.Exists(Path.Combine(directory, payloadFileName)))
+                .OrderByDescending(directory =>
+                    string.Equals(Path.GetFileName(directory), activeHash, StringComparison.OrdinalIgnoreCase)
+                        ? DateTime.MaxValue
+                        : Directory.GetLastWriteTimeUtc(directory))
+                .ToArray();
 
-                TryDeleteOldShadow(directory);
+            foreach (var directory in shadows.Skip(PreviousPayloadShadowsToKeep + 1))
+            {
+                TryDeleteShadow(directory);
             }
         }
         catch
@@ -171,16 +198,10 @@ public sealed class GameLauncher
         }
     }
 
-    private static void TryDeleteOldShadow(string directory)
+    private static void TryDeleteShadow(string directory)
     {
         try
         {
-            var age = DateTime.UtcNow - Directory.GetLastWriteTimeUtc(directory);
-            if (age < TimeSpan.FromDays(1))
-            {
-                return;
-            }
-
             Directory.Delete(directory, recursive: true);
         }
         catch

--- a/Shared/P2PTransportProtocol.cs
+++ b/Shared/P2PTransportProtocol.cs
@@ -10,7 +10,12 @@ namespace SKYNET.Protocol
         SocketsAccept = 3,
         SocketsReject = 4,
         SocketsClose = 5,
-        SocketsData = 6
+        SocketsData = 6,
+        LegacySocketsOpen = 7,
+        LegacySocketsAccept = 8,
+        LegacySocketsReject = 9,
+        LegacySocketsClose = 10,
+        LegacySocketsData = 11
     }
 
     /// <summary>
@@ -43,6 +48,16 @@ namespace SKYNET.Protocol
                     return "sockets_close";
                 case P2PTransportKind.SocketsData:
                     return "sockets_data";
+                case P2PTransportKind.LegacySocketsOpen:
+                    return "legacy_sockets_open";
+                case P2PTransportKind.LegacySocketsAccept:
+                    return "legacy_sockets_accept";
+                case P2PTransportKind.LegacySocketsReject:
+                    return "legacy_sockets_reject";
+                case P2PTransportKind.LegacySocketsClose:
+                    return "legacy_sockets_close";
+                case P2PTransportKind.LegacySocketsData:
+                    return "legacy_sockets_data";
                 default:
                     throw new ArgumentOutOfRangeException(nameof(transport), transport, "Unknown P2P transport.");
             }
@@ -96,6 +111,21 @@ namespace SKYNET.Protocol
                     break;
                 case "sockets_data":
                     transport = P2PTransportKind.SocketsData;
+                    break;
+                case "legacy_sockets_open":
+                    transport = P2PTransportKind.LegacySocketsOpen;
+                    break;
+                case "legacy_sockets_accept":
+                    transport = P2PTransportKind.LegacySocketsAccept;
+                    break;
+                case "legacy_sockets_reject":
+                    transport = P2PTransportKind.LegacySocketsReject;
+                    break;
+                case "legacy_sockets_close":
+                    transport = P2PTransportKind.LegacySocketsClose;
+                    break;
+                case "legacy_sockets_data":
+                    transport = P2PTransportKind.LegacySocketsData;
                     break;
                 default:
                     error = "Unknown P2P transport.";
@@ -205,6 +235,35 @@ namespace SKYNET.Protocol
                         "Socket close and data frames require a source connection ID.",
                         out error);
 
+                case P2PTransportKind.LegacySocketsOpen:
+                    return ValidateSocketFrame(
+                        channel,
+                        sourceConnectionId != 0 && targetConnectionId == 0,
+                        "Legacy socket open frames require only a source connection ID.",
+                        out error);
+
+                case P2PTransportKind.LegacySocketsAccept:
+                    return ValidateSocketFrame(
+                        channel,
+                        sourceConnectionId != 0 && targetConnectionId != 0,
+                        "Legacy socket accept frames require source and target connection IDs.",
+                        out error);
+
+                case P2PTransportKind.LegacySocketsReject:
+                    return ValidateSocketFrame(
+                        channel,
+                        targetConnectionId != 0,
+                        "Legacy socket reject frames require a target connection ID.",
+                        out error);
+
+                case P2PTransportKind.LegacySocketsClose:
+                case P2PTransportKind.LegacySocketsData:
+                    return ValidateSocketFrame(
+                        channel,
+                        sourceConnectionId != 0,
+                        "Legacy socket close and data frames require a source connection ID.",
+                        out error);
+
                 default:
                     error = "Unknown P2P transport.";
                     return false;
@@ -287,10 +346,18 @@ namespace SKYNET.Protocol
                    transport <= P2PTransportKind.SocketsData;
         }
 
+        public static bool IsLegacySockets(P2PTransportKind transport)
+        {
+            return transport >= P2PTransportKind.LegacySocketsOpen &&
+                   transport <= P2PTransportKind.LegacySocketsData;
+        }
+
         public static bool IsSocketControl(P2PTransportKind transport)
         {
-            return transport >= P2PTransportKind.SocketsOpen &&
-                   transport <= P2PTransportKind.SocketsClose;
+            return (transport >= P2PTransportKind.SocketsOpen &&
+                    transport <= P2PTransportKind.SocketsClose) ||
+                   (transport >= P2PTransportKind.LegacySocketsOpen &&
+                    transport <= P2PTransportKind.LegacySocketsClose);
         }
 
         private static bool ValidateSocketFrame(

--- a/steam_api/Callback/CallbackBaseInvoker.cs
+++ b/steam_api/Callback/CallbackBaseInvoker.cs
@@ -8,17 +8,19 @@ namespace SKYNET.Callback
 {
     internal static class CallbackBaseInvoker
     {
+        // MSVC reverses these two overloads in the vtable. This is the same
+        // overload-order rule used by MsvcVTableOverloadAttribute elsewhere.
         private const int RunCallResultVTableSlot = 0;
         private const int RunCallbackVTableSlot = 1;
         private const int GetCallbackSizeVTableSlot = 2;
-        private const int CallbackFlagsOffset64 = 8;
-        private const int CallbackIdOffset64 = 12;
 
         private static readonly object Gate = new object();
         private static readonly Dictionary<IntPtr, RunCallbackDelegate> RunCallbackDelegates = new Dictionary<IntPtr, RunCallbackDelegate>();
         private static readonly Dictionary<IntPtr, RunCallResultDelegate> RunCallResultDelegates = new Dictionary<IntPtr, RunCallResultDelegate>();
         private static readonly Dictionary<IntPtr, GetCallbackSizeDelegate> GetCallbackSizeDelegates = new Dictionary<IntPtr, GetCallbackSizeDelegate>();
-        private static bool unsupportedArchitectureLogged;
+        private static readonly Dictionary<IntPtr, RunCallbackThisCallDelegate> RunCallbackThisCallDelegates = new Dictionary<IntPtr, RunCallbackThisCallDelegate>();
+        private static readonly Dictionary<IntPtr, RunCallResultThisCallDelegate> RunCallResultThisCallDelegates = new Dictionary<IntPtr, RunCallResultThisCallDelegate>();
+        private static readonly Dictionary<IntPtr, GetCallbackSizeThisCallDelegate> GetCallbackSizeThisCallDelegates = new Dictionary<IntPtr, GetCallbackSizeThisCallDelegate>();
 
         public static bool RunCallback(IntPtr self, IntPtr pvParam)
         {
@@ -27,8 +29,14 @@ namespace SKYNET.Callback
                 return false;
             }
 
-            var invoker = GetDelegate(function, RunCallbackDelegates);
-            invoker(self, pvParam);
+            if (IntPtr.Size == 4)
+            {
+                GetDelegate(function, RunCallbackThisCallDelegates)(self, pvParam);
+            }
+            else
+            {
+                GetDelegate(function, RunCallbackDelegates)(self, pvParam);
+            }
             return true;
         }
 
@@ -39,8 +47,14 @@ namespace SKYNET.Callback
                 return false;
             }
 
-            var invoker = GetDelegate(function, RunCallResultDelegates);
-            invoker(self, pvParam, ioFailure ? (byte)1 : (byte)0, apiCall);
+            if (IntPtr.Size == 4)
+            {
+                GetDelegate(function, RunCallResultThisCallDelegates)(self, pvParam, ioFailure ? (byte)1 : (byte)0, apiCall);
+            }
+            else
+            {
+                GetDelegate(function, RunCallResultDelegates)(self, pvParam, ioFailure ? (byte)1 : (byte)0, apiCall);
+            }
             return true;
         }
 
@@ -51,8 +65,9 @@ namespace SKYNET.Callback
                 return 0;
             }
 
-            var invoker = GetDelegate(function, GetCallbackSizeDelegates);
-            return invoker(self);
+            return IntPtr.Size == 4
+                ? GetDelegate(function, GetCallbackSizeThisCallDelegates)(self)
+                : GetDelegate(function, GetCallbackSizeDelegates)(self);
         }
 
         public static int GetCallbackId(IntPtr self)
@@ -62,7 +77,7 @@ namespace SKYNET.Callback
                 return 0;
             }
 
-            return Marshal.ReadInt32(self, CallbackIdOffset64);
+            return Marshal.ReadInt32(self, IntPtr.Size + 4);
         }
 
         public static byte GetCallbackFlags(IntPtr self)
@@ -72,30 +87,30 @@ namespace SKYNET.Callback
                 return 0;
             }
 
-            return Marshal.ReadByte(self, CallbackFlagsOffset64);
+            return Marshal.ReadByte(self, IntPtr.Size);
         }
 
         public static void RegisterCallback(IntPtr self, int callbackId)
         {
-            if (!IsSupportedCallbackPointer(self))
+            if (!IsSupportedCallbackPointer(self) || IntPtr.Size == 4)
             {
                 return;
             }
 
             var flags = (byte)(GetCallbackFlags(self) | CallbackConstants.Registered);
-            Marshal.WriteByte(self, CallbackFlagsOffset64, flags);
-            Marshal.WriteInt32(self, CallbackIdOffset64, callbackId);
+            Marshal.WriteByte(self, IntPtr.Size, flags);
+            Marshal.WriteInt32(self, IntPtr.Size + 4, callbackId);
         }
 
         public static void UnregisterCallback(IntPtr self)
         {
-            if (!IsSupportedCallbackPointer(self))
+            if (!IsSupportedCallbackPointer(self) || IntPtr.Size == 4)
             {
                 return;
             }
 
             var flags = (byte)(GetCallbackFlags(self) & ~CallbackConstants.Registered);
-            Marshal.WriteByte(self, CallbackFlagsOffset64, flags);
+            Marshal.WriteByte(self, IntPtr.Size, flags);
         }
 
         private static bool TryGetVTableFunction(IntPtr self, int slot, out IntPtr function)
@@ -123,18 +138,7 @@ namespace SKYNET.Callback
                 return false;
             }
 
-            if (IntPtr.Size == 8)
-            {
-                return true;
-            }
-
-            if (!unsupportedArchitectureLogged)
-            {
-                unsupportedArchitectureLogged = true;
-                SteamEmulator.Write("CallbackManager", "CCallbackBase direct vtable dispatch is only enabled for x64");
-            }
-
-            return false;
+            return IntPtr.Size == 4 || IntPtr.Size == 8;
         }
 
         private static TDelegate GetDelegate<TDelegate>(IntPtr function, Dictionary<IntPtr, TDelegate> cache)
@@ -164,5 +168,18 @@ namespace SKYNET.Callback
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate int GetCallbackSizeDelegate(IntPtr self);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        private delegate void RunCallbackThisCallDelegate(IntPtr self, IntPtr pvParam);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        private delegate void RunCallResultThisCallDelegate(
+            IntPtr self,
+            IntPtr pvParam,
+            byte ioFailure,
+            SteamAPICall_t apiCall);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        private delegate int GetCallbackSizeThisCallDelegate(IntPtr self);
     }
 }

--- a/steam_api/Callback/CallbackEnums.cs
+++ b/steam_api/Callback/CallbackEnums.cs
@@ -153,7 +153,7 @@ namespace SKYNET.Callback
         LeaderboardUGCSet = 1111,
         // PS3TrophiesInstalled = 1112,
         GlobalStatsReceived = 1112,
-        // SocketStatusCallback = 1201,
+        SocketStatusCallback = 1201,
         P2PSessionRequest = 1202,
         P2PSessionConnectFail = 1203,
         SteamNetConnectionStatusChangedCallback = 1221,

--- a/steam_api/Callback/CallbackTypes.cs
+++ b/steam_api/Callback/CallbackTypes.cs
@@ -1656,6 +1656,21 @@ namespace SKYNET.Callback
     //}
 
     [StructLayout(LayoutKind.Sequential, Pack = Platform.StructPlatformPackSize)]
+    public struct SocketStatusCallback_t : ICallbackData
+    {
+        public uint m_hSocket;
+        public uint m_hListenSocket;
+        public ulong m_steamIDRemote;
+        public int m_eSNetSocketState;
+
+        #region SteamCallback
+        public static int _datasize = Marshal.SizeOf(typeof(SocketStatusCallback_t));
+        public int DataSize => _datasize;
+        public CallbackType CallbackType => CallbackType.SocketStatusCallback;
+        #endregion
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = Platform.StructPlatformPackSize)]
     public struct P2PSessionRequest_t : ICallbackData
     {
         public ulong m_steamIDRemote; // m_steamIDRemote CSteamID

--- a/steam_api/Managers/CallbackManager.cs
+++ b/steam_api/Managers/CallbackManager.cs
@@ -172,8 +172,10 @@ namespace SKYNET.Managers
         {
             EventPump.RunFrame(gameServer);
             NativeCallbackQueue.Drain(gameServer);
-            var invocations = DrainForFrame(gameServer, SteamEmulator.HSteamPipe, SteamEmulator.HSteamUser);
+            var frameUtc = DateTime.UtcNow;
+            var invocations = DrainForFrame(gameServer, SteamEmulator.HSteamPipe, SteamEmulator.HSteamUser, frameUtc);
             InvokeCallbacks(invocations);
+            ClearPendingDirectCallbacks(gameServer, frameUtc);
         }
 
         public static void ManualDispatchInit()
@@ -185,8 +187,10 @@ namespace SKYNET.Managers
             bool gameServer = hSteamPipe == SteamEmulator.HSteamPipe_GS;
             EventPump.RunFrame(gameServer);
             NativeCallbackQueue.Drain(gameServer);
-            var invocations = DrainForFrame(gameServer, hSteamPipe, gameServer ? SteamEmulator.HSteamUser_GS : SteamEmulator.HSteamUser);
+            var frameUtc = DateTime.UtcNow;
+            var invocations = DrainForFrame(gameServer, hSteamPipe, gameServer ? SteamEmulator.HSteamUser_GS : SteamEmulator.HSteamUser, frameUtc);
             InvokeCallbacks(invocations);
+            ClearPendingDirectCallbacks(gameServer, frameUtc);
         }
 
         public static bool ManualDispatchGetNextCallback(HSteamPipe hSteamPipe, ref CallbackMsg_t callbackMsg)
@@ -459,15 +463,12 @@ namespace SKYNET.Managers
             }
         }
 
-        private static List<CallbackInvocation> DrainForFrame(bool gameServer, HSteamPipe steamPipe, HSteamUser steamUser)
+        private static List<CallbackInvocation> DrainForFrame(bool gameServer, HSteamPipe steamPipe, HSteamUser steamUser, DateTime now)
         {
-            var now = DateTime.UtcNow;
             lock (Gate)
             {
                 RemoveDeletedAndExpired(now);
-                var invocations = DrainReadyRecords(gameServer, now);
-                ClearPendingDirectCallbacks(gameServer);
-                return invocations;
+                return DrainReadyRecords(gameServer, now);
             }
         }
 
@@ -643,11 +644,19 @@ namespace SKYNET.Managers
             });
         }
 
-        private static void ClearPendingDirectCallbacks(bool gameServer)
+        private static void ClearPendingDirectCallbacks(bool gameServer, DateTime createdThroughUtc)
         {
-            foreach (var key in PendingDirectCallbacks.Keys.Where(k => k.GameServer == gameServer).ToArray())
+            lock (Gate)
             {
-                PendingDirectCallbacks.Remove(key);
+                foreach (var key in PendingDirectCallbacks.Keys.Where(k => k.GameServer == gameServer).ToArray())
+                {
+                    var pendingCallbacks = PendingDirectCallbacks[key];
+                    pendingCallbacks.RemoveAll(pending => pending.CreatedUtc <= createdThroughUtc);
+                    if (pendingCallbacks.Count == 0)
+                    {
+                        PendingDirectCallbacks.Remove(key);
+                    }
+                }
             }
         }
 
@@ -671,6 +680,14 @@ namespace SKYNET.Managers
 
         private static CallbackRecord FindRecord(ulong apiCall)
         {
+            // Steam defines zero as k_uAPICallInvalid. Direct callbacks also use
+            // ApiCall == 0 internally, so looking up zero can otherwise return an
+            // unrelated direct callback and make an invalid handle appear valid.
+            if (apiCall == 0)
+            {
+                return null;
+            }
+
             return Records.LastOrDefault(r => r.ApiCall == apiCall);
         }
 

--- a/steam_api/Managers/EventPump.cs
+++ b/steam_api/Managers/EventPump.cs
@@ -366,6 +366,18 @@ namespace SKYNET.Managers
                 return;
             }
 
+            if (P2PTransportProtocol.IsLegacySockets(transport))
+            {
+                SteamEmulator.SteamNetworking?.ProcessRelaySocketPacket(
+                    transport,
+                    remoteSteamId,
+                    serverEvent.VirtualPort,
+                    serverEvent.SourceConnectionId,
+                    serverEvent.TargetConnectionId,
+                    payload);
+                return;
+            }
+
             if (transport != P2PTransportKind.Legacy)
             {
                 SteamEmulator.Write("EventPump", $"Dropping unhandled P2P transport: {transport}");

--- a/steam_api/SteamEmulator.cs
+++ b/steam_api/SteamEmulator.cs
@@ -339,7 +339,7 @@ public class SteamEmulator
             string appid_Path = Path.Combine(Common.GetPath(), "steam_appid.txt");
             if (File.Exists(appid_Path))
             {
-                string content = File.ReadAllText(appid_Path).Trim();
+                string content = File.ReadAllText(appid_Path).Trim('\0', ' ', '\t', '\r', '\n');
                 if (uint.TryParse(content, out var appId) && appId != 0)
                 {
                     InternalAppId = appId;
@@ -546,6 +546,3 @@ public class SteamEmulator
         MessageBox.Show("DEBUG");
     }
 }
-
-
-

--- a/steam_api/Steamworks/Exported/CSteamworks.cs
+++ b/steam_api/Steamworks/Exported/CSteamworks.cs
@@ -3999,9 +3999,15 @@ namespace SKYNET.Steamworks.Exported
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
-        public static bool ISteamUtils_IsAPICallCompleted(SteamAPICall_t hSteamAPICall, ref bool pbFailed)
+        public static bool ISteamUtils_IsAPICallCompleted(SteamAPICall_t hSteamAPICall, IntPtr pbFailed)
         {
-            return SteamEmulator.SteamUtils.IsAPICallCompleted(hSteamAPICall, ref pbFailed);
+            bool failed = false;
+            bool result = SteamEmulator.SteamUtils.IsAPICallCompleted(hSteamAPICall, ref failed);
+            if (pbFailed != IntPtr.Zero)
+            {
+                Marshal.WriteByte(pbFailed, failed ? (byte)1 : (byte)0);
+            }
+            return result;
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
@@ -4011,9 +4017,15 @@ namespace SKYNET.Steamworks.Exported
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
-        public static bool ISteamUtils_GetAPICallResult(SteamAPICall_t hSteamAPICall, IntPtr pCallback, int cubCallback, int iCallbackExpected, ref bool pbFailed)
+        public static bool ISteamUtils_GetAPICallResult(SteamAPICall_t hSteamAPICall, IntPtr pCallback, int cubCallback, int iCallbackExpected, IntPtr pbFailed)
         {
-            return SteamEmulator.SteamUtils.GetAPICallResult(hSteamAPICall, pCallback, cubCallback, iCallbackExpected, ref pbFailed);
+            bool failed = false;
+            bool result = SteamEmulator.SteamUtils.GetAPICallResult(hSteamAPICall, pCallback, cubCallback, iCallbackExpected, ref failed);
+            if (pbFailed != IntPtr.Zero)
+            {
+                Marshal.WriteByte(pbFailed, failed ? (byte)1 : (byte)0);
+            }
+            return result;
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
@@ -4583,9 +4595,15 @@ namespace SKYNET.Steamworks.Exported
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
-        public static bool ISteamGameServerUtils_IsAPICallCompleted(SteamAPICall_t hSteamAPICall, ref bool pbFailed)
+        public static bool ISteamGameServerUtils_IsAPICallCompleted(SteamAPICall_t hSteamAPICall, IntPtr pbFailed)
         {
-            return SteamEmulator.SteamUtils.IsAPICallCompleted(hSteamAPICall, ref pbFailed);
+            bool failed = false;
+            bool result = SteamEmulator.SteamUtils.IsAPICallCompleted(hSteamAPICall, ref failed);
+            if (pbFailed != IntPtr.Zero)
+            {
+                Marshal.WriteByte(pbFailed, failed ? (byte)1 : (byte)0);
+            }
+            return result;
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
@@ -4595,9 +4613,15 @@ namespace SKYNET.Steamworks.Exported
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
-        public static bool ISteamGameServerUtils_GetAPICallResult(SteamAPICall_t hSteamAPICall, IntPtr pCallback, int cubCallback, int iCallbackExpected, ref bool pbFailed)
+        public static bool ISteamGameServerUtils_GetAPICallResult(SteamAPICall_t hSteamAPICall, IntPtr pCallback, int cubCallback, int iCallbackExpected, IntPtr pbFailed)
         {
-            return SteamEmulator.SteamUtils.GetAPICallResult(hSteamAPICall, pCallback, cubCallback, iCallbackExpected, ref pbFailed);
+            bool failed = false;
+            bool result = SteamEmulator.SteamUtils.GetAPICallResult(hSteamAPICall, pCallback, cubCallback, iCallbackExpected, ref failed);
+            if (pbFailed != IntPtr.Zero)
+            {
+                Marshal.WriteByte(pbFailed, failed ? (byte)1 : (byte)0);
+            }
+            return result;
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]

--- a/steam_api/Steamworks/Exported/SteamAPI.cs
+++ b/steam_api/Steamworks/Exported/SteamAPI.cs
@@ -14,6 +14,20 @@ namespace SKYNET.Steamworks.Exported
 {
     public class SteamAPI
     {
+        private const uint PageExecuteReadWrite = 0x40;
+        private static readonly object LegacyGameServerExportSync = new object();
+        private static bool legacyGameServerExportPrepared;
+        private static IntPtr legacyGameServerExportSlot;
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Ansi, SetLastError = true)]
+        private static extern IntPtr GetModuleHandle(string lpModuleName);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Ansi, SetLastError = true)]
+        private static extern IntPtr GetProcAddress(IntPtr hModule, string lpProcName);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool VirtualProtect(IntPtr lpAddress, UIntPtr dwSize, uint flNewProtect, out uint lpflOldProtect);
+
         static SteamAPI()
         {
             if (!SteamEmulator.Initialized && !SteamEmulator.Initializing)
@@ -130,14 +144,17 @@ namespace SKYNET.Steamworks.Exported
         public static bool SteamAPI_InitSafe()
         {
             Write("SteamAPI_InitSafe");
-            return SteamAPI_Init();
+            // DllExport adds a CallConvCdecl modopt to exported method signatures.
+            // A managed call compiled before that rewrite no longer matches the
+            // rewritten signature and throws MissingMethodException at runtime.
+            return InitializeClientApi(IntPtr.Zero) == 0;
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
         public static bool SteamAPI_InitAnonymousUser()
         {
             Write("SteamAPI_InitAnonymousUser");
-            return SteamAPI_Init();
+            return InitializeClientApi(IntPtr.Zero) == 0;
         }
 
         internal static int InitializeClientApi(IntPtr pOutErrMsg)
@@ -148,6 +165,7 @@ namespace SKYNET.Steamworks.Exported
 
             if (APIClient.EnsureInitialSession())
             {
+                PrepareLegacyGameServerExport();
                 NativeStringCache.WriteUtf8Buffer(
                     pOutErrMsg,
                     SteamErrorMessageCapacity,
@@ -162,6 +180,102 @@ namespace SKYNET.Steamworks.Exported
                 error);
             Write(error);
             return SteamApiInitNoSteamClient;
+        }
+
+        /// <summary>
+        /// Left 4 Dead's Steamworks generation imports g_pSteamClientGameServer as
+        /// writable data. DllExport can only emit a method export, so for AppID 500
+        /// the exported thunk itself is used as the four-byte legacy pointer slot.
+        /// </summary>
+        internal static void PrepareLegacyGameServerExport()
+        {
+            if (SteamEmulator.InternalAppId != 500 || legacyGameServerExportPrepared)
+            {
+                return;
+            }
+
+            lock (LegacyGameServerExportSync)
+            {
+                if (legacyGameServerExportPrepared)
+                {
+                    return;
+                }
+
+                IntPtr module = GetModuleHandle("steam_api.dll");
+                IntPtr slot = module == IntPtr.Zero
+                    ? IntPtr.Zero
+                    : GetProcAddress(module, "g_pSteamClientGameServer");
+
+                if (slot == IntPtr.Zero)
+                {
+                    Write("Legacy g_pSteamClientGameServer export was not found");
+                    return;
+                }
+
+                IntPtr client = InterfaceManager.FindOrCreateInterface(
+                    SteamEmulator.HSteamUser_GS,
+                    SteamEmulator.HSteamPipe_GS,
+                    "SteamClient009",
+                    true);
+
+                if (client == IntPtr.Zero || !WriteLegacyGameServerExport(slot, client))
+                {
+                    Write($"Unable to prepare legacy g_pSteamClientGameServer export ({Marshal.GetLastWin32Error()})");
+                    return;
+                }
+
+                legacyGameServerExportSlot = slot;
+                legacyGameServerExportPrepared = true;
+                Write("Prepared legacy g_pSteamClientGameServer data export");
+            }
+        }
+
+        internal static void PublishLegacyGameServerClient()
+        {
+            if (SteamEmulator.InternalAppId != 500)
+            {
+                return;
+            }
+
+            PrepareLegacyGameServerExport();
+            if (!legacyGameServerExportPrepared)
+            {
+                return;
+            }
+
+            IntPtr client = InterfaceManager.FindOrCreateInterface(
+                SteamEmulator.HSteamUser_GS,
+                SteamEmulator.HSteamPipe_GS,
+                "SteamClient009",
+                true);
+
+            if (client == IntPtr.Zero || !WriteLegacyGameServerExport(legacyGameServerExportSlot, client))
+            {
+                Write("Unable to publish legacy g_pSteamClientGameServer interface");
+                return;
+            }
+
+            Write("Published legacy g_pSteamClientGameServer interface");
+        }
+
+        private static bool WriteLegacyGameServerExport(IntPtr slot, IntPtr value)
+        {
+            uint oldProtect;
+            if (!VirtualProtect(slot, (UIntPtr)IntPtr.Size, PageExecuteReadWrite, out oldProtect))
+            {
+                return false;
+            }
+
+            try
+            {
+                Marshal.WriteIntPtr(slot, value);
+                return true;
+            }
+            finally
+            {
+                uint ignored;
+                VirtualProtect(slot, (UIntPtr)IntPtr.Size, oldProtect, out ignored);
+            }
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
@@ -214,14 +328,22 @@ namespace SKYNET.Steamworks.Exported
         public static HSteamPipe GetHSteamPipe()
         {
             Write("GetHSteamPipe");
-            return SteamAPI_GetHSteamPipe();
+            if (SteamEmulator.HSteamPipe == 0)
+            {
+                SteamEmulator.CreateSteamPipe();
+            }
+            return SteamEmulator.HSteamPipe;
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
         public static HSteamUser GetHSteamUser()
         {
             Write("GetHSteamUser");
-            return SteamAPI_GetHSteamUser();
+            if (SteamEmulator.HSteamUser == 0)
+            {
+                SteamEmulator.CreateSteamUser();
+            }
+            return SteamEmulator.HSteamUser;
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
@@ -275,10 +397,16 @@ namespace SKYNET.Steamworks.Exported
 
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
-        public static bool SteamAPI_ManualDispatch_GetAPICallResult(HSteamPipe hSteamPipe, SteamAPICall_t hSteamAPICall, IntPtr pCallback, int cubCallback, int iCallbackExpected, ref bool pbFailed)
+        public static bool SteamAPI_ManualDispatch_GetAPICallResult(HSteamPipe hSteamPipe, SteamAPICall_t hSteamAPICall, IntPtr pCallback, int cubCallback, int iCallbackExpected, IntPtr pbFailed)
         {
             Write($"SteamAPI_ManualDispatch_GetAPICallResult");
-            return CallbackManager.ManualDispatchGetAPICallResult(hSteamPipe, hSteamAPICall, pCallback, cubCallback, iCallbackExpected, ref pbFailed);
+            bool failed = false;
+            bool result = CallbackManager.ManualDispatchGetAPICallResult(hSteamPipe, hSteamAPICall, pCallback, cubCallback, iCallbackExpected, ref failed);
+            if (pbFailed != IntPtr.Zero)
+            {
+                Marshal.WriteByte(pbFailed, failed ? (byte)1 : (byte)0);
+            }
+            return result;
         }
 
 
@@ -298,13 +426,31 @@ namespace SKYNET.Steamworks.Exported
             Msg += $" {pchMsg}" + Environment.NewLine;
             Msg += " //////////////////////////////   End Mini Dump   \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\" + Environment.NewLine;
             //Write(Msg);
-            Write("SteamAPI_SetMiniDumpComment");
+            Write($"SteamAPI_SetMiniDumpComment: {pchMsg ?? string.Empty}");
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
         public static void SteamAPI_WriteMiniDump(UInt32 uStructuredExceptionCode, IntPtr pvExceptionInfo, UInt32 uBuildID)
         {
-            Write($"SteamAPI_WriteMiniDump");
+            IntPtr exceptionAddress = IntPtr.Zero;
+            try
+            {
+                if (pvExceptionInfo != IntPtr.Zero)
+                {
+                    IntPtr exceptionRecord = Marshal.ReadIntPtr(pvExceptionInfo);
+                    if (exceptionRecord != IntPtr.Zero)
+                    {
+                        exceptionAddress = Marshal.ReadIntPtr(exceptionRecord, 12);
+                    }
+                }
+            }
+            catch
+            {
+                // The process is already handling a native exception. Logging must
+                // never replace the original failure with a marshaling failure.
+            }
+
+            Write($"SteamAPI_WriteMiniDump code=0x{uStructuredExceptionCode:X8} address=0x{exceptionAddress.ToInt64():X} info=0x{pvExceptionInfo.ToInt64():X} build={uBuildID}");
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
@@ -747,7 +893,12 @@ namespace SKYNET.Steamworks.Exported
         public static IntPtr SteamClient()
         {
             Write($"SteamClient");
-            return InterfaceManager.FindOrCreateInterface("SteamClient023");
+            // The SteamClient() export has no version argument. Legacy steam_api
+            // wrappers therefore expect the exact client vtable that shipped with
+            // their game. Left 4 Dead (AppID 500) uses SteamClient009; returning the
+            // modern vtable shifts every slot after GetISteamMatchmaking.
+            string version = SteamEmulator.InternalAppId == 500 ? "SteamClient009" : "SteamClient023";
+            return InterfaceManager.FindOrCreateInterface(version);
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]

--- a/steam_api/Steamworks/Exported/SteamAPI_ISteamGameServer.cs
+++ b/steam_api/Steamworks/Exported/SteamAPI_ISteamGameServer.cs
@@ -22,10 +22,15 @@ namespace SKYNET.Steamworks.Exported
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
-        public static bool SteamAPI_ISteamGameServer_InitGameServer(IntPtr _, uint unIP, ushort usGamePort, ushort usQueryPort, uint unFlags, AppId_t nGameAppId, string pchVersionString)
+        public static bool SteamAPI_ISteamGameServer_InitGameServer(IntPtr _, uint unIP, ushort usGamePort, ushort usQueryPort, uint unFlags, AppId_t nGameAppId, IntPtr pchVersionString)
         {
-            Write("SteamAPI_ISteamGameServer_InitGameServer");
-            return SteamEmulator.SteamGameServer.InitGameServer(unIP, usGamePort, usQueryPort, unFlags, nGameAppId, pchVersionString);
+            Write($"SteamAPI_ISteamGameServer_InitGameServer version=0x{pchVersionString.ToInt64():X}");
+            bool initialized = SteamEmulator.SteamGameServer.InitGameServer(unIP, usGamePort, usQueryPort, unFlags, nGameAppId, ReadAnsiArgument(pchVersionString));
+            if (initialized)
+            {
+                SteamAPI.PublishLegacyGameServerClient();
+            }
+            return initialized;
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
@@ -351,17 +356,76 @@ namespace SKYNET.Steamworks.Exported
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
-        public static bool SteamGameServer_Init(uint unIP, int usGamePort, int usQueryPort, uint unFlags, uint nGameAppId, string pchVersionString)
+        public static bool SteamGameServer_Init(uint unIP, ushort usGamePort, ushort usQueryPort, EServerMode eServerMode, IntPtr pchVersionString)
         {
-            Write("SteamGameServer_Init");
-            return SteamEmulator.SteamGameServer.InitGameServer(unIP, usGamePort, usQueryPort, unFlags, nGameAppId, pchVersionString);
+            Write($"SteamGameServer_Init IP={unIP} gamePort={usGamePort} queryPort={usQueryPort} mode={eServerMode} version=0x{pchVersionString.ToInt64():X}");
+            bool initialized = SteamEmulator.SteamGameServer.InitGameServer(
+                unIP,
+                usGamePort,
+                usQueryPort,
+                GetLegacyServerFlags(eServerMode),
+                SteamEmulator.InternalAppId,
+                ReadAnsiArgument(pchVersionString));
+            if (initialized)
+            {
+                SteamAPI.PublishLegacyGameServerClient();
+            }
+            return initialized;
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
-        public static bool SteamGameServer_InitSafe(uint unIP, ushort usSteamPort, ushort usGamePort, ushort usQueryPort, EServerMode eServerMode, string pchVersionString)
+        public static bool SteamGameServer_InitSafe(
+            uint unIP,
+            ushort usSteamPort,
+            ushort usGamePort,
+            ushort usSpectatorPort,
+            ushort usQueryPort,
+            EServerMode eServerMode,
+            IntPtr pchVersionString)
         {
-            Write("SteamGameServer_InitSafe");
-            return SteamEmulator.SteamGameServer.InitGameServer(unIP, usGamePort, usQueryPort, 0, (uint)eServerMode, pchVersionString);
+            Write($"SteamGameServer_InitSafe IP={unIP} steamPort={usSteamPort} gamePort={usGamePort} spectatorPort={usSpectatorPort} queryPort={usQueryPort} mode={eServerMode} version=0x{pchVersionString.ToInt64():X}");
+            bool initialized = SteamEmulator.SteamGameServer.InitGameServer(
+                unIP,
+                usGamePort,
+                usQueryPort,
+                GetLegacyServerFlags(eServerMode),
+                SteamEmulator.InternalAppId,
+                ReadAnsiArgument(pchVersionString));
+            SteamEmulator.SteamGameServer.SetSpectatorPort(usSpectatorPort);
+            if (initialized)
+            {
+                SteamAPI.PublishLegacyGameServerClient();
+            }
+            return initialized;
+        }
+
+        private static uint GetLegacyServerFlags(EServerMode serverMode)
+        {
+            return serverMode == EServerMode.AuthenticationAndSecure
+                ? Constants.k_unServerFlagSecure
+                : Constants.k_unServerFlagNone;
+        }
+
+        private static string ReadAnsiArgument(IntPtr value)
+        {
+            long address = value.ToInt64();
+            if (address == 0)
+            {
+                return string.Empty;
+            }
+            if (address > 0 && address < 0x10000)
+            {
+                return $"<invalid:0x{address:X}>";
+            }
+
+            try
+            {
+                return Marshal.PtrToStringAnsi(value) ?? string.Empty;
+            }
+            catch
+            {
+                return $"<invalid:0x{address:X}>";
+            }
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]

--- a/steam_api/Steamworks/Exported/SteamAPI_ISteamUtils.cs
+++ b/steam_api/Steamworks/Exported/SteamAPI_ISteamUtils.cs
@@ -92,10 +92,16 @@ namespace SKYNET.Steamworks.Exported
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
-        public static bool SteamAPI_ISteamUtils_IsAPICallCompleted(IntPtr _, SteamAPICall_t hSteamAPICall, ref bool pbFailed)
+        public static bool SteamAPI_ISteamUtils_IsAPICallCompleted(IntPtr _, SteamAPICall_t hSteamAPICall, IntPtr pbFailed)
         {
             Write("SteamAPI_ISteamUtils_IsAPICallCompleted");
-            return SteamEmulator.SteamUtils.IsAPICallCompleted(hSteamAPICall, ref pbFailed);
+            bool failed = false;
+            bool result = SteamEmulator.SteamUtils.IsAPICallCompleted(hSteamAPICall, ref failed);
+            if (pbFailed != IntPtr.Zero)
+            {
+                Marshal.WriteByte(pbFailed, failed ? (byte)1 : (byte)0);
+            }
+            return result;
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
@@ -106,10 +112,16 @@ namespace SKYNET.Steamworks.Exported
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
-        public static bool SteamAPI_ISteamUtils_GetAPICallResult(IntPtr _, SteamAPICall_t hSteamAPICall, IntPtr pCallback, int cubCallback, int iCallbackExpected, ref bool pbFailed)
+        public static bool SteamAPI_ISteamUtils_GetAPICallResult(IntPtr _, SteamAPICall_t hSteamAPICall, IntPtr pCallback, int cubCallback, int iCallbackExpected, IntPtr pbFailed)
         {
             Write("SteamAPI_ISteamUtils_GetAPICallResult");
-            return SteamEmulator.SteamUtils.GetAPICallResult(hSteamAPICall, pCallback, cubCallback, iCallbackExpected, ref pbFailed);
+            bool failed = false;
+            bool result = SteamEmulator.SteamUtils.GetAPICallResult(hSteamAPICall, pCallback, cubCallback, iCallbackExpected, ref failed);
+            if (pbFailed != IntPtr.Zero)
+            {
+                Marshal.WriteByte(pbFailed, failed ? (byte)1 : (byte)0);
+            }
+            return result;
         }
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]

--- a/steam_api/Steamworks/Implementation/SteamNetworking.cs
+++ b/steam_api/Steamworks/Implementation/SteamNetworking.cs
@@ -3,17 +3,17 @@ using SKYNET.Helpers;
 //using SKYNET.IPC.Types;
 using SKYNET.Network.Packets;
 using SKYNET.Managers;
+using SKYNET.Protocol;
 using SKYNET.Steamworks.Interfaces;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net;
-using System.Net.Sockets;
 using System.Runtime.InteropServices;
-using System.Text;
+using System.Threading;
 
 using SNetListenSocket_t = System.UInt32;
 using SNetSocket_t = System.UInt32;
-using System.Linq;
 
 namespace SKYNET.Steamworks.Implementation
 {
@@ -21,10 +21,42 @@ namespace SKYNET.Steamworks.Implementation
     {
         public static SteamNetworking Instance;
         private static List<ulong> P2PSession;
+        private const int SocketStateInvalid = 0;
+        private const int SocketStateConnected = 1;
+        private const int SocketStateInitiated = 10;
+        private const int SocketStateLocalDisconnect = 22;
+        private const int SocketStateTimeoutDuringConnect = 23;
+        private const int SocketStateRemoteEndDisconnected = 24;
+        private const int MaxQueuedSocketPackets = 2048;
+
+        private readonly object _socketGate = new object();
+        private readonly Dictionary<uint, LegacyListenSocket> _listenSockets = new Dictionary<uint, LegacyListenSocket>();
+        private readonly Dictionary<uint, LegacySocket> _sockets = new Dictionary<uint, LegacySocket>();
+        private int _nextSocketHandle;
 
         public List<NET_P2PPacket> P2PIncoming;
-        public Dictionary<SNetSocket_t, Socket> P2PSocket;
-        public Dictionary<SNetListenSocket_t, Socket> P2PListenSocket;
+
+        private sealed class LegacyListenSocket
+        {
+            internal uint Handle;
+            internal int VirtualPort;
+            internal uint IP;
+            internal ushort Port;
+        }
+
+        private sealed class LegacySocket
+        {
+            internal uint Handle;
+            internal uint ListenSocket;
+            internal ulong RemoteSteamId;
+            internal int VirtualPort;
+            internal uint PeerConnectionId;
+            internal uint RemoteIP = 0;
+            internal ushort RemotePort = 0;
+            internal int State;
+            internal readonly ConcurrentQueue<byte[]> Incoming = new ConcurrentQueue<byte[]>();
+            internal int IncomingCount;
+        }
 
         public SteamNetworking()
         {
@@ -32,8 +64,6 @@ namespace SKYNET.Steamworks.Implementation
             InterfaceName = "SteamNetworking";
             InterfaceVersion = "SteamNetworking006";
             P2PIncoming = new List<NET_P2PPacket>();
-            P2PSocket = new Dictionary<SNetListenSocket_t, Socket>();
-            P2PListenSocket = new Dictionary<SNetListenSocket_t, Socket>();
             P2PSession = new List<ulong>();
         }
 
@@ -174,146 +204,605 @@ namespace SKYNET.Steamworks.Implementation
 
         public SNetListenSocket_t CreateListenSocket(int nVirtualP2PPort, uint nIP, uint nPort, bool bAllowUseOfPacketRelay)
         {
-            Write("CreateListenSocket");
-            return 0;
+            return CreateLegacyListenSocket(nVirtualP2PPort, nIP, unchecked((ushort)nPort));
         }
 
         public SNetListenSocket_t CreateListenSocket(int nVirtualP2PPort, SteamIPAddress_t nIP, ushort nPort, bool bAllowUseOfPacketRelay)
         {
-            Write("CreateListenSocket");
-            return 0;
+            var address = nIP.ToIPAddress();
+            var ipv4 = address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork
+                ? NetworkManager.GetIPAddress(address)
+                : 0;
+            return CreateLegacyListenSocket(nVirtualP2PPort, ipv4, nPort);
         }
 
         public SNetSocket_t CreateP2PConnectionSocket(ulong steamIDTarget, int nVirtualPort, int nTimeoutSec, bool bAllowUseOfPacketRelay)
         {
-            Write("CreateP2PConnectionSocket");
-            return 0;
+            if (steamIDTarget == 0 || !APIClient.IsEnabled)
+            {
+                Write($"CreateP2PConnectionSocket rejected target={steamIDTarget} API={APIClient.IsEnabled}");
+                return 0;
+            }
+
+            LegacySocket socket;
+            lock (_socketGate)
+            {
+                socket = new LegacySocket
+                {
+                    Handle = AllocateSocketHandleLocked(),
+                    RemoteSteamId = steamIDTarget,
+                    VirtualPort = nVirtualPort,
+                    State = SocketStateInitiated
+                };
+                _sockets.Add(socket.Handle, socket);
+            }
+
+            Write($"CreateP2PConnectionSocket handle={socket.Handle} target={steamIDTarget} virtualPort={nVirtualPort}");
+            if (!SendSocketFrame(socket, P2PTransportKind.LegacySocketsOpen, Array.Empty<byte>()))
+            {
+                lock (_socketGate)
+                {
+                    socket.State = SocketStateTimeoutDuringConnect;
+                }
+                EmitSocketStatus(socket);
+            }
+            return socket.Handle;
         }
 
         public SNetSocket_t CreateConnectionSocket(uint nIP, uint nPort, int nTimeoutSec)
         {
-            Write("CreateConnectionSocket");
+            Write($"CreateConnectionSocket unsupported IP={nIP} port={nPort}");
             return 0;
         }
 
         public SNetSocket_t CreateConnectionSocket(SteamIPAddress_t nIP, ushort nPort, int nTimeoutSec)
         {
-            Write("CreateConnectionSocket");
+            Write($"CreateConnectionSocket unsupported IP={nIP} port={nPort}");
             return 0;
         }
 
         public bool DestroySocket(SNetSocket_t hSocket, bool bNotifyRemoteEnd)
         {
-            Write("DestroySocket");
-            return false;
+            LegacySocket socket;
+            lock (_socketGate)
+            {
+                if (!_sockets.TryGetValue(hSocket, out socket))
+                {
+                    return false;
+                }
+                socket.State = SocketStateLocalDisconnect;
+                _sockets.Remove(hSocket);
+            }
+
+            Write($"DestroySocket handle={hSocket}");
+            if (bNotifyRemoteEnd && socket.RemoteSteamId != 0)
+            {
+                SendSocketFrame(socket, P2PTransportKind.LegacySocketsClose, Array.Empty<byte>());
+            }
+            EmitSocketStatus(socket);
+            return true;
         }
 
         public bool DestroyListenSocket(SNetListenSocket_t hSocket, bool bNotifyRemoteEnd)
         {
-            Write("DestroyListenSocket");
-            return false;
+            var affected = new List<LegacySocket>();
+            lock (_socketGate)
+            {
+                if (!_listenSockets.Remove(hSocket))
+                {
+                    return false;
+                }
+
+                foreach (var pair in new List<KeyValuePair<uint, LegacySocket>>(_sockets))
+                {
+                    if (pair.Value.ListenSocket == hSocket)
+                    {
+                        pair.Value.State = SocketStateLocalDisconnect;
+                        affected.Add(pair.Value);
+                        _sockets.Remove(pair.Key);
+                    }
+                }
+            }
+
+            Write($"DestroyListenSocket handle={hSocket} connections={affected.Count}");
+            foreach (var socket in affected)
+            {
+                if (bNotifyRemoteEnd)
+                {
+                    SendSocketFrame(socket, P2PTransportKind.LegacySocketsClose, Array.Empty<byte>());
+                }
+                EmitSocketStatus(socket);
+            }
+            return true;
         }
 
         public bool SendDataOnSocket(SNetSocket_t hSocket, IntPtr pubData, uint cubData, bool bReliable)
         {
-            Write("SendDataOnSocket");
-            return false;
+            if ((cubData > 0 && pubData == IntPtr.Zero) || cubData > 1024 * 1024)
+            {
+                return false;
+            }
+
+            LegacySocket socket;
+            lock (_socketGate)
+            {
+                if (!_sockets.TryGetValue(hSocket, out socket) || socket.State != SocketStateConnected)
+                {
+                    return false;
+                }
+            }
+
+            var payload = new byte[cubData];
+            if (payload.Length > 0)
+            {
+                Marshal.Copy(pubData, payload, 0, payload.Length);
+            }
+            return SendSocketFrame(socket, P2PTransportKind.LegacySocketsData, payload, bReliable ? 2 : 0);
         }
 
         public bool IsDataAvailableOnSocket(SNetSocket_t hSocket, uint pcubMsgSize)
         {
-            Write("IsDataAvailableOnSocket");
-            return false;
+            lock (_socketGate)
+            {
+                return _sockets.TryGetValue(hSocket, out var socket) && socket.Incoming.TryPeek(out _);
+            }
         }
 
         public bool IsDataAvailableOnSocket(SNetSocket_t hSocket, IntPtr pcubMsgSize)
         {
-            Write("IsDataAvailableOnSocket");
-            WriteUInt32(pcubMsgSize, 0);
-            return false;
+            LegacySocket socket;
+            lock (_socketGate)
+            {
+                if (!_sockets.TryGetValue(hSocket, out socket) || !socket.Incoming.TryPeek(out var payload))
+                {
+                    WriteUInt32(pcubMsgSize, 0);
+                    return false;
+                }
+                WriteUInt32(pcubMsgSize, (uint)payload.Length);
+                return true;
+            }
         }
 
         public bool RetrieveDataFromSocket(SNetSocket_t hSocket, IntPtr pubDest, uint cubDest, uint pcubMsgSize)
         {
-            Write("RetrieveDataFromSocket");
-            return false;
+            return RetrieveDataFromSocket(hSocket, pubDest, cubDest, IntPtr.Zero);
         }
 
         public bool RetrieveDataFromSocket(SNetSocket_t hSocket, IntPtr pubDest, uint cubDest, IntPtr pcubMsgSize)
         {
-            Write("RetrieveDataFromSocket");
-            WriteUInt32(pcubMsgSize, 0);
-            return false;
+            LegacySocket socket;
+            lock (_socketGate)
+            {
+                if (!_sockets.TryGetValue(hSocket, out socket))
+                {
+                    WriteUInt32(pcubMsgSize, 0);
+                    return false;
+                }
+            }
+
+            if (!socket.Incoming.TryDequeue(out var payload))
+            {
+                WriteUInt32(pcubMsgSize, 0);
+                return false;
+            }
+
+            Interlocked.Decrement(ref socket.IncomingCount);
+            WriteUInt32(pcubMsgSize, (uint)payload.Length);
+            var copyLength = Math.Min(payload.Length, unchecked((int)cubDest));
+            if (copyLength > 0 && pubDest != IntPtr.Zero)
+            {
+                Marshal.Copy(payload, 0, pubDest, copyLength);
+            }
+            return true;
         }
 
         public bool IsDataAvailable(SNetListenSocket_t hListenSocket, uint pcubMsgSize, SNetSocket_t phSocket)
         {
-            Write("IsDataAvailable");
-            return false;
+            return TryFindSocketWithData(hListenSocket, out _, out _);
         }
 
         public bool IsDataAvailable(SNetListenSocket_t hListenSocket, IntPtr pcubMsgSize, IntPtr phSocket)
         {
-            Write("IsDataAvailable");
-            WriteUInt32(pcubMsgSize, 0);
-            WriteUInt32(phSocket, 0);
-            return false;
+            if (!TryFindSocketWithData(hListenSocket, out var socket, out var payload))
+            {
+                WriteUInt32(pcubMsgSize, 0);
+                WriteUInt32(phSocket, 0);
+                return false;
+            }
+            WriteUInt32(pcubMsgSize, (uint)payload.Length);
+            WriteUInt32(phSocket, socket.Handle);
+            return true;
         }
 
         public bool RetrieveData(SNetListenSocket_t hListenSocket, IntPtr pubDest, uint cubDest, uint pcubMsgSize, SNetSocket_t phSocket)
         {
-            Write("RetrieveData");
-            return false;
+            if (!TryFindSocketWithData(hListenSocket, out var socket, out _))
+            {
+                return false;
+            }
+            return RetrieveDataFromSocket(socket.Handle, pubDest, cubDest, IntPtr.Zero);
         }
 
         public bool RetrieveData(SNetListenSocket_t hListenSocket, IntPtr pubDest, uint cubDest, IntPtr pcubMsgSize, IntPtr phSocket)
         {
-            Write("RetrieveData");
-            WriteUInt32(pcubMsgSize, 0);
-            WriteUInt32(phSocket, 0);
-            return false;
+            if (!TryFindSocketWithData(hListenSocket, out var socket, out _))
+            {
+                WriteUInt32(pcubMsgSize, 0);
+                WriteUInt32(phSocket, 0);
+                return false;
+            }
+            WriteUInt32(phSocket, socket.Handle);
+            return RetrieveDataFromSocket(socket.Handle, pubDest, cubDest, pcubMsgSize);
         }
 
         public bool GetSocketInfo(SNetSocket_t hSocket, ulong pSteamIDRemote, int peSocketStatus, uint punIPRemote, uint punPortRemote)
         {
-            Write("GetSocketInfo");
-            return false;
+            lock (_socketGate)
+            {
+                return _sockets.ContainsKey(hSocket);
+            }
         }
 
         public bool GetSocketInfo(SNetSocket_t hSocket, IntPtr pSteamIDRemote, IntPtr peSocketStatus, IntPtr punIPRemote, IntPtr punPortRemote)
         {
-            Write("GetSocketInfo");
-            WriteUInt64(pSteamIDRemote, 0);
-            WriteInt32(peSocketStatus, 0);
-            WriteSteamIPAddress(punIPRemote, default);
-            WriteUInt16(punPortRemote, 0);
-            return false;
+            lock (_socketGate)
+            {
+                if (!_sockets.TryGetValue(hSocket, out var socket))
+                {
+                    WriteUInt64(pSteamIDRemote, 0);
+                    WriteInt32(peSocketStatus, SocketStateInvalid);
+                    WriteUInt32(punIPRemote, 0);
+                    WriteUInt16(punPortRemote, 0);
+                    return false;
+                }
+                WriteUInt64(pSteamIDRemote, socket.RemoteSteamId);
+                WriteInt32(peSocketStatus, socket.State);
+                WriteUInt32(punIPRemote, socket.RemoteIP);
+                WriteUInt16(punPortRemote, socket.RemotePort);
+                return true;
+            }
         }
 
         public bool GetListenSocketInfo(SNetListenSocket_t hListenSocket, uint pnIP, uint pnPort)
         {
-            Write("GetListenSocketInfo");
-            return false;
+            lock (_socketGate)
+            {
+                return _listenSockets.ContainsKey(hListenSocket);
+            }
         }
 
         public bool GetListenSocketInfo(SNetListenSocket_t hListenSocket, IntPtr pnIP, IntPtr pnPort)
         {
-            Write("GetListenSocketInfo");
-            WriteSteamIPAddress(pnIP, default);
-            WriteUInt16(pnPort, 0);
-            return false;
+            lock (_socketGate)
+            {
+                if (!_listenSockets.TryGetValue(hListenSocket, out var listener))
+                {
+                    WriteUInt32(pnIP, 0);
+                    WriteUInt16(pnPort, 0);
+                    return false;
+                }
+                WriteUInt32(pnIP, listener.IP);
+                WriteUInt16(pnPort, listener.Port);
+                return true;
+            }
         }
 
         public int GetSocketConnectionType(SNetSocket_t hSocket)
         {
-            Write("GetSocketConnectionType");
-            return default;
+            lock (_socketGate)
+            {
+                return _sockets.TryGetValue(hSocket, out var socket) && socket.State == SocketStateConnected
+                    ? (int)ESNetSocketConnectionType.k_ESNetSocketConnectionTypeUDPRelay
+                    : (int)ESNetSocketConnectionType.k_ESNetSocketConnectionTypeNotConnected;
+            }
         }
 
         public int GetMaxPacketSize(SNetSocket_t hSocket)
         {
-            Write("GetMaxPacketSize");
-            return 1500;
+            return 1200;
+        }
+
+        internal void ProcessRelaySocketPacket(
+            P2PTransportKind transport,
+            ulong remoteSteamId,
+            int virtualPort,
+            uint sourceConnectionId,
+            uint targetConnectionId,
+            byte[] payload)
+        {
+            switch (transport)
+            {
+                case P2PTransportKind.LegacySocketsOpen:
+                    ProcessSocketOpen(remoteSteamId, virtualPort, sourceConnectionId);
+                    break;
+                case P2PTransportKind.LegacySocketsAccept:
+                    ProcessSocketAccept(remoteSteamId, virtualPort, sourceConnectionId, targetConnectionId);
+                    break;
+                case P2PTransportKind.LegacySocketsReject:
+                    ProcessSocketClosed(remoteSteamId, virtualPort, sourceConnectionId, targetConnectionId, SocketStateTimeoutDuringConnect);
+                    break;
+                case P2PTransportKind.LegacySocketsClose:
+                    ProcessSocketClosed(remoteSteamId, virtualPort, sourceConnectionId, targetConnectionId, SocketStateRemoteEndDisconnected);
+                    break;
+                case P2PTransportKind.LegacySocketsData:
+                    ProcessSocketData(remoteSteamId, virtualPort, sourceConnectionId, targetConnectionId, payload ?? Array.Empty<byte>());
+                    break;
+            }
+        }
+
+        private SNetListenSocket_t CreateLegacyListenSocket(int virtualPort, uint ip, ushort port)
+        {
+            lock (_socketGate)
+            {
+                foreach (var existing in _listenSockets.Values)
+                {
+                    if (existing.VirtualPort == virtualPort && existing.IP == ip && existing.Port == port)
+                    {
+                        Write($"CreateListenSocket reused handle={existing.Handle} virtualPort={virtualPort} IP={ip} port={port}");
+                        return existing.Handle;
+                    }
+                }
+
+                var listener = new LegacyListenSocket
+                {
+                    Handle = AllocateSocketHandleLocked(),
+                    VirtualPort = virtualPort,
+                    IP = ip,
+                    Port = port
+                };
+                _listenSockets.Add(listener.Handle, listener);
+                Write($"CreateListenSocket handle={listener.Handle} virtualPort={virtualPort} IP={ip} port={port}");
+                return listener.Handle;
+            }
+        }
+
+        private void ProcessSocketOpen(ulong remoteSteamId, int virtualPort, uint sourceConnectionId)
+        {
+            LegacySocket socket = null;
+            lock (_socketGate)
+            {
+                foreach (var existing in _sockets.Values)
+                {
+                    if (existing.ListenSocket != 0 &&
+                        existing.RemoteSteamId == remoteSteamId &&
+                        existing.VirtualPort == virtualPort &&
+                        existing.PeerConnectionId == sourceConnectionId)
+                    {
+                        return;
+                    }
+                }
+
+                LegacyListenSocket listener = null;
+                foreach (var candidate in _listenSockets.Values)
+                {
+                    if (candidate.VirtualPort == virtualPort)
+                    {
+                        listener = candidate;
+                        break;
+                    }
+                }
+
+                if (listener != null)
+                {
+                    socket = new LegacySocket
+                    {
+                        Handle = AllocateSocketHandleLocked(),
+                        ListenSocket = listener.Handle,
+                        RemoteSteamId = remoteSteamId,
+                        VirtualPort = virtualPort,
+                        PeerConnectionId = sourceConnectionId,
+                        State = SocketStateConnected
+                    };
+                    _sockets.Add(socket.Handle, socket);
+                }
+            }
+
+            if (socket == null)
+            {
+                SendSocketFrame(
+                    remoteSteamId,
+                    virtualPort,
+                    P2PTransportKind.LegacySocketsReject,
+                    Array.Empty<byte>(),
+                    targetConnectionId: sourceConnectionId);
+                return;
+            }
+
+            Write($"Accepted legacy socket handle={socket.Handle} remote={remoteSteamId} virtualPort={virtualPort}");
+            SendSocketFrame(
+                remoteSteamId,
+                virtualPort,
+                P2PTransportKind.LegacySocketsAccept,
+                Array.Empty<byte>(),
+                sourceConnectionId: socket.Handle,
+                targetConnectionId: sourceConnectionId);
+            EmitSocketStatus(socket);
+        }
+
+        private void ProcessSocketAccept(ulong remoteSteamId, int virtualPort, uint sourceConnectionId, uint targetConnectionId)
+        {
+            LegacySocket socket = null;
+            lock (_socketGate)
+            {
+                if (_sockets.TryGetValue(targetConnectionId, out var candidate) &&
+                    candidate.ListenSocket == 0 &&
+                    candidate.RemoteSteamId == remoteSteamId &&
+                    candidate.VirtualPort == virtualPort &&
+                    candidate.State == SocketStateInitiated)
+                {
+                    candidate.PeerConnectionId = sourceConnectionId;
+                    candidate.State = SocketStateConnected;
+                    socket = candidate;
+                }
+            }
+
+            if (socket != null)
+            {
+                Write($"Connected legacy socket handle={socket.Handle} remote={remoteSteamId} virtualPort={virtualPort}");
+                EmitSocketStatus(socket);
+            }
+        }
+
+        private void ProcessSocketClosed(
+            ulong remoteSteamId,
+            int virtualPort,
+            uint sourceConnectionId,
+            uint targetConnectionId,
+            int state)
+        {
+            LegacySocket socket = null;
+            lock (_socketGate)
+            {
+                foreach (var candidate in _sockets.Values)
+                {
+                    if (MatchesSocket(candidate, remoteSteamId, virtualPort, sourceConnectionId, targetConnectionId))
+                    {
+                        candidate.State = state;
+                        socket = candidate;
+                        break;
+                    }
+                }
+            }
+
+            if (socket != null)
+            {
+                EmitSocketStatus(socket);
+            }
+        }
+
+        private void ProcessSocketData(
+            ulong remoteSteamId,
+            int virtualPort,
+            uint sourceConnectionId,
+            uint targetConnectionId,
+            byte[] payload)
+        {
+            LegacySocket socket = null;
+            lock (_socketGate)
+            {
+                foreach (var candidate in _sockets.Values)
+                {
+                    if (MatchesSocket(candidate, remoteSteamId, virtualPort, sourceConnectionId, targetConnectionId) &&
+                        candidate.State == SocketStateConnected)
+                    {
+                        socket = candidate;
+                        break;
+                    }
+                }
+            }
+
+            if (socket == null || Interlocked.Increment(ref socket.IncomingCount) > MaxQueuedSocketPackets)
+            {
+                if (socket != null)
+                {
+                    Interlocked.Decrement(ref socket.IncomingCount);
+                }
+                Write("Dropping legacy socket packet because the connection is unknown or its queue is full");
+                return;
+            }
+            socket.Incoming.Enqueue(payload);
+        }
+
+        private bool TryFindSocketWithData(uint listenSocket, out LegacySocket socket, out byte[] payload)
+        {
+            socket = null;
+            payload = null;
+            lock (_socketGate)
+            {
+                if (!_listenSockets.ContainsKey(listenSocket))
+                {
+                    return false;
+                }
+
+                foreach (var candidate in _sockets.Values)
+                {
+                    if (candidate.ListenSocket == listenSocket && candidate.Incoming.TryPeek(out payload))
+                    {
+                        socket = candidate;
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+
+        private bool SendSocketFrame(
+            LegacySocket socket,
+            P2PTransportKind transport,
+            byte[] payload,
+            int sendType = 0)
+        {
+            return SendSocketFrame(
+                socket.RemoteSteamId,
+                socket.VirtualPort,
+                transport,
+                payload,
+                sendType,
+                socket.Handle,
+                socket.PeerConnectionId);
+        }
+
+        private static bool SendSocketFrame(
+            ulong remoteSteamId,
+            int virtualPort,
+            P2PTransportKind transport,
+            byte[] payload,
+            int sendType = 0,
+            uint sourceConnectionId = 0,
+            uint targetConnectionId = 0)
+        {
+            return remoteSteamId != 0 && APIClient.SendP2PPacket(
+                remoteSteamId,
+                payload,
+                sendType,
+                0,
+                transport,
+                virtualPort,
+                sourceConnectionId,
+                targetConnectionId);
+        }
+
+        private static bool MatchesSocket(
+            LegacySocket socket,
+            ulong remoteSteamId,
+            int virtualPort,
+            uint sourceConnectionId,
+            uint targetConnectionId)
+        {
+            if (socket.RemoteSteamId != remoteSteamId || socket.VirtualPort != virtualPort)
+            {
+                return false;
+            }
+            if (targetConnectionId != 0 && socket.Handle != targetConnectionId)
+            {
+                return false;
+            }
+            return sourceConnectionId == 0 ||
+                   socket.PeerConnectionId == 0 ||
+                   socket.PeerConnectionId == sourceConnectionId;
+        }
+
+        private uint AllocateSocketHandleLocked()
+        {
+            while (true)
+            {
+                var handle = unchecked((uint)Interlocked.Increment(ref _nextSocketHandle));
+                if (handle != 0 && !_listenSockets.ContainsKey(handle) && !_sockets.ContainsKey(handle))
+                {
+                    return handle;
+                }
+            }
+        }
+
+        private static void EmitSocketStatus(LegacySocket socket)
+        {
+            CallbackManager.AddCallback(new SocketStatusCallback_t
+            {
+                m_hSocket = socket.Handle,
+                m_hListenSocket = socket.ListenSocket,
+                m_steamIDRemote = socket.RemoteSteamId,
+                m_eSNetSocketState = socket.State
+            });
         }
 
         public void AddP2PPacket(NET_P2PPacket p2p)

--- a/steam_api/Steamworks/Implementation/SteamUtils.cs
+++ b/steam_api/Steamworks/Implementation/SteamUtils.cs
@@ -257,9 +257,16 @@ namespace SKYNET.Steamworks.Implementation
 
         public SteamAPICall_t CheckFileSignature(string szFileName)
         {
-            Write("CheckFileSignature");
-            // CheckFileSignature_t
-            return k_uAPICallInvalid;
+            Write($"CheckFileSignature ({szFileName ?? string.Empty})");
+
+            // This API is asynchronous. Returning k_uAPICallInvalid makes games
+            // poll handle zero, which is not a valid SteamAPICall_t. The emulator
+            // owns the supplied files, so report a successful signature check via
+            // the normal call-result path.
+            return CallbackManager.AddCallbackResult(new CheckFileSignature_t
+            {
+                CheckFileSignature = global::SKYNET.Steamworks.CheckFileSignature.ValidSignature
+            });
         }
 
         public bool ShowGamepadTextInput(int eInputMode, int eLineInputMode, string pchDescription, uint unCharMax, string pchExistingText)

--- a/steam_api/Steamworks/Interfaces/SteamApps/SteamApps003.cs
+++ b/steam_api/Steamworks/Interfaces/SteamApps/SteamApps003.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace SKYNET.Steamworks.Interfaces
+{
+    /// <summary>Legacy ISteamApps ABI used by Left 4 Dead.</summary>
+    [Interface("STEAMAPPS_INTERFACE_VERSION003")]
+    public class SteamApps003 : ISteamInterface
+    {
+        public bool BIsSubscribed(IntPtr _) => SteamEmulator.SteamApps.BIsSubscribed();
+        public bool BIsLowViolence(IntPtr _) => SteamEmulator.SteamApps.BIsLowViolence();
+        public bool BIsCybercafe(IntPtr _) => SteamEmulator.SteamApps.BIsCybercafe();
+        public bool BIsVACBanned(IntPtr _) => SteamEmulator.SteamApps.BIsVACBanned();
+        public IntPtr GetCurrentGameLanguage(IntPtr _) => SteamEmulator.SteamApps.GetCurrentGameLanguage();
+        public IntPtr GetAvailableGameLanguages(IntPtr _) => SteamEmulator.SteamApps.GetAvailableGameLanguages();
+        public bool BIsSubscribedApp(IntPtr _, uint appID) => SteamEmulator.SteamApps.BIsSubscribedApp(appID);
+        public bool BIsDlcInstalled(IntPtr _, uint appID) => SteamEmulator.SteamApps.BIsDlcInstalled(appID);
+    }
+}

--- a/steam_api/Steamworks/Interfaces/SteamClient/SteamClient009.cs
+++ b/steam_api/Steamworks/Interfaces/SteamClient/SteamClient009.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Runtime.InteropServices;
+
+using HSteamPipe = System.UInt32;
+using HSteamUser = System.UInt32;
+
+namespace SKYNET.Steamworks.Interfaces
+{
+    /// <summary>Legacy ISteamClient ABI used by Left 4 Dead (AppID 500).</summary>
+    [Interface("SteamClient009")]
+    public class SteamClient009 : ISteamInterface
+    {
+        public HSteamPipe CreateSteamPipe(IntPtr _) => SteamEmulator.SteamClient.CreateSteamPipe();
+
+        public bool BReleaseSteamPipe(IntPtr _, HSteamPipe hSteamPipe) =>
+            SteamEmulator.SteamClient.BReleaseSteamPipe(hSteamPipe);
+
+        public HSteamUser ConnectToGlobalUser(IntPtr _, HSteamPipe hSteamPipe) =>
+            SteamEmulator.SteamClient.ConnectToGlobalUser(hSteamPipe);
+
+        public HSteamUser CreateLocalUser(IntPtr _, IntPtr phSteamPipe, int eAccountType)
+        {
+            HSteamPipe pipe = SteamEmulator.CreateSteamPipe();
+            if (phSteamPipe != IntPtr.Zero)
+            {
+                Marshal.WriteInt32(phSteamPipe, unchecked((int)pipe));
+            }
+            return SteamEmulator.SteamClient.CreateLocalUser(pipe, eAccountType);
+        }
+
+        public void ReleaseUser(IntPtr _, HSteamPipe hSteamPipe, HSteamUser hUser) =>
+            SteamEmulator.SteamClient.ReleaseUser(hSteamPipe, hUser);
+
+        public IntPtr GetISteamUser(IntPtr _, HSteamUser hSteamUser, HSteamPipe hSteamPipe, string pchVersion) =>
+            SteamEmulator.SteamClient.GetISteamUser(hSteamUser, hSteamPipe, pchVersion);
+
+        public IntPtr GetISteamGameServer(IntPtr _, HSteamUser hSteamUser, HSteamPipe hSteamPipe, string pchVersion) =>
+            SteamEmulator.SteamClient.GetISteamGameServer(hSteamUser, hSteamPipe, pchVersion);
+
+        public void SetLocalIPBinding(IntPtr _, uint unIP, ushort usPort) =>
+            SteamEmulator.SteamClient.SetLocalIPBinding(unIP, usPort);
+
+        public IntPtr GetISteamFriends(IntPtr _, HSteamUser hSteamUser, HSteamPipe hSteamPipe, string pchVersion) =>
+            SteamEmulator.SteamClient.GetISteamFriends(hSteamUser, hSteamPipe, pchVersion);
+
+        public IntPtr GetISteamUtils(IntPtr _, HSteamPipe hSteamPipe, string pchVersion) =>
+            SteamEmulator.SteamClient.GetISteamUtils(hSteamPipe, pchVersion);
+
+        public IntPtr GetISteamMatchmaking(IntPtr _, HSteamUser hSteamUser, HSteamPipe hSteamPipe, string pchVersion) =>
+            SteamEmulator.SteamClient.GetISteamMatchmaking(hSteamUser, hSteamPipe, pchVersion);
+
+        public IntPtr GetISteamMasterServerUpdater(IntPtr _, HSteamUser hSteamUser, HSteamPipe hSteamPipe, string pchVersion) =>
+            SteamEmulator.SteamClient.GetISteamMasterServerUpdater(hSteamUser, hSteamPipe, pchVersion);
+
+        public IntPtr GetISteamMatchmakingServers(IntPtr _, HSteamUser hSteamUser, HSteamPipe hSteamPipe, string pchVersion) =>
+            SteamEmulator.SteamClient.GetISteamMatchmakingServers(hSteamUser, hSteamPipe, pchVersion);
+
+        public IntPtr GetISteamGenericInterface(IntPtr _, HSteamUser hSteamUser, HSteamPipe hSteamPipe, string pchVersion) =>
+            SteamEmulator.SteamClient.GetISteamGenericInterface(hSteamUser, hSteamPipe, pchVersion);
+
+        public IntPtr GetISteamUserStats(IntPtr _, HSteamUser hSteamUser, HSteamPipe hSteamPipe, string pchVersion) =>
+            SteamEmulator.SteamClient.GetISteamUserStats(hSteamUser, hSteamPipe, pchVersion);
+
+        public IntPtr GetISteamGameServerStats(IntPtr _, HSteamUser hSteamUser, HSteamPipe hSteamPipe, string pchVersion) =>
+            SteamEmulator.SteamClient.GetISteamGameServerStats(hSteamUser, hSteamPipe, pchVersion);
+
+        public IntPtr GetISteamApps(IntPtr _, HSteamUser hSteamUser, HSteamPipe hSteamPipe, string pchVersion) =>
+            SteamEmulator.SteamClient.GetISteamApps(hSteamUser, hSteamPipe, pchVersion);
+
+        public IntPtr GetISteamNetworking(IntPtr _, HSteamUser hSteamUser, HSteamPipe hSteamPipe, string pchVersion) =>
+            SteamEmulator.SteamClient.GetISteamNetworking(hSteamUser, hSteamPipe, pchVersion);
+
+        public IntPtr GetISteamRemoteStorage(IntPtr _, HSteamUser hSteamUser, HSteamPipe hSteamPipe, string pchVersion) =>
+            SteamEmulator.SteamClient.GetISteamRemoteStorage(hSteamUser, hSteamPipe, pchVersion);
+
+        public void RunFrame(IntPtr _) => SteamEmulator.SteamClient.RunFrame();
+        public uint GetIPCCallCount(IntPtr _) => SteamEmulator.SteamClient.GetIPCCallCount();
+
+        public void SetWarningMessageHook(IntPtr _, IntPtr pFunction) =>
+            SteamEmulator.SteamClient.SetWarningMessageHook(pFunction);
+    }
+}

--- a/steam_api/Steamworks/Interfaces/SteamFriends/SteamFriends005.cs
+++ b/steam_api/Steamworks/Interfaces/SteamFriends/SteamFriends005.cs
@@ -1,0 +1,99 @@
+using System;
+using SKYNET.Helpers;
+using SKYNET.Steamworks.Implementation;
+
+namespace SKYNET.Steamworks.Interfaces
+{
+    /// <summary>
+    /// Legacy ISteamFriends ABI used by the original Left 4 Dead Steamworks SDK.
+    /// The interface contains exactly 24 vtable slots and predates the async
+    /// SetPersonaName return value and the overlay-to-store flag argument.
+    /// </summary>
+    [Interface("SteamFriends005")]
+    public class SteamFriends005 : ISteamInterface
+    {
+        public string GetPersonaName(IntPtr _) => SteamFriends.Instance.GetPersonaName();
+
+        public void SetPersonaNameOld(IntPtr _, string pchPersonaName)
+        {
+            SteamFriends.Instance.SetPersonaName(pchPersonaName);
+        }
+
+        public EPersonaState GetPersonaState(IntPtr _) =>
+            (EPersonaState)SteamFriends.Instance.GetPersonaState();
+
+        public int GetFriendCount(IntPtr _, int eFriendFlags) =>
+            SteamFriends.Instance.GetFriendCount(eFriendFlags);
+
+        public IntPtr GetFriendByIndex(IntPtr _, IntPtr ret, int iFriend, int iFriendFlags) =>
+            NativeSteamId.Write(ret, SteamFriends.Instance.GetFriendByIndex(iFriend, iFriendFlags));
+
+        public EFriendRelationship GetFriendRelationship(IntPtr _, ulong steamIDFriend) =>
+            (EFriendRelationship)SteamFriends.Instance.GetFriendRelationship(steamIDFriend);
+
+        public EPersonaState GetFriendPersonaState(IntPtr _, ulong steamIDFriend) =>
+            (EPersonaState)SteamFriends.Instance.GetFriendPersonaState(steamIDFriend);
+
+        public string GetFriendPersonaName(IntPtr _, ulong steamIDFriend) =>
+            SteamFriends.Instance.GetFriendPersonaName(steamIDFriend);
+
+        public int GetFriendAvatar(IntPtr _, ulong steamIDFriend, int eAvatarSize)
+        {
+            switch (eAvatarSize)
+            {
+                case 0:
+                    return SteamFriends.Instance.GetSmallFriendAvatar(steamIDFriend);
+                case 1:
+                    return SteamFriends.Instance.GetMediumFriendAvatar(steamIDFriend);
+                case 2:
+                    return SteamFriends.Instance.GetLargeFriendAvatar(steamIDFriend);
+                default:
+                    return 0;
+            }
+        }
+
+        public bool GetFriendGamePlayed(IntPtr _, ulong steamIDFriend, ref FriendGameInfo_t pFriendGameInfo) =>
+            SteamFriends.Instance.GetFriendGamePlayed(steamIDFriend, ref pFriendGameInfo);
+
+        public string GetFriendPersonaNameHistory(IntPtr _, ulong steamIDFriend, int iPersonaName) =>
+            SteamFriends.Instance.GetFriendPersonaNameHistory(steamIDFriend, iPersonaName);
+
+        public bool HasFriend(IntPtr _, ulong steamIDFriend, int eFriendFlags) =>
+            SteamFriends.Instance.HasFriend(steamIDFriend, eFriendFlags);
+
+        public int GetClanCount(IntPtr _) => SteamFriends.Instance.GetClanCount();
+
+        public IntPtr GetClanByIndex(IntPtr _, IntPtr ret, int iClan) =>
+            NativeSteamId.Write(ret, SteamFriends.Instance.GetClanByIndex(iClan));
+
+        public string GetClanName(IntPtr _, ulong steamIDClan) =>
+            SteamFriends.Instance.GetClanName(steamIDClan);
+
+        public int GetFriendCountFromSource(IntPtr _, ulong steamIDSource) =>
+            SteamFriends.Instance.GetFriendCountFromSource(steamIDSource);
+
+        public IntPtr GetFriendFromSourceByIndex(IntPtr _, IntPtr ret, ulong steamIDSource, int iFriend) =>
+            NativeSteamId.Write(ret, SteamFriends.Instance.GetFriendFromSourceByIndex(steamIDSource, iFriend));
+
+        public bool IsUserInSource(IntPtr _, ulong steamIDUser, ulong steamIDSource) =>
+            SteamFriends.Instance.IsUserInSource(steamIDUser, steamIDSource);
+
+        public void SetInGameVoiceSpeaking(IntPtr _, ulong steamIDUser, bool bSpeaking) =>
+            SteamFriends.Instance.SetInGameVoiceSpeaking(steamIDUser, bSpeaking);
+
+        public void ActivateGameOverlay(IntPtr _, string pchDialog) =>
+            SteamFriends.Instance.ActivateGameOverlay(pchDialog);
+
+        public void ActivateGameOverlayToUser(IntPtr _, string pchDialog, ulong steamID) =>
+            SteamFriends.Instance.ActivateGameOverlayToUser(pchDialog, steamID);
+
+        public void ActivateGameOverlayToWebPage(IntPtr _, string pchURL) =>
+            SteamFriends.Instance.ActivateGameOverlayToWebPage(pchURL, 0);
+
+        public void ActivateGameOverlayToStore(IntPtr _, uint nAppID) =>
+            SteamFriends.Instance.ActivateGameOverlayToStore(nAppID, 0);
+
+        public void SetPlayedWith(IntPtr _, ulong steamIDUserPlayedWith) =>
+            SteamFriends.Instance.SetPlayedWith(steamIDUserPlayedWith);
+    }
+}

--- a/steam_api/Steamworks/Interfaces/SteamGameServer/SteamGameServer009.cs
+++ b/steam_api/Steamworks/Interfaces/SteamGameServer/SteamGameServer009.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Runtime.InteropServices;
+using SKYNET.Helpers;
+
+namespace SKYNET.Steamworks.Interfaces
+{
+    /// <summary>Legacy ISteamGameServer ABI used by Left 4 Dead.</summary>
+    [Interface("SteamGameServer009")]
+    public class SteamGameServer009 : ISteamInterface
+    {
+        public void LogOn(IntPtr _)
+        {
+            SteamEmulator.SteamGameServer.LogOnAnonymous();
+        }
+
+        public void LogOff(IntPtr _)
+        {
+            SteamEmulator.SteamGameServer.LogOff();
+        }
+
+        public bool BLoggedOn(IntPtr _)
+        {
+            return SteamEmulator.SteamGameServer.BLoggedOn();
+        }
+
+        public bool BSecure(IntPtr _)
+        {
+            return SteamEmulator.SteamGameServer.BSecure();
+        }
+
+        public IntPtr GetSteamID(IntPtr _, IntPtr pSteamID)
+        {
+            return NativeSteamId.Write(pSteamID, SteamEmulator.SteamGameServer.GetSteamID());
+        }
+
+        public bool SendUserConnectAndAuthenticate(IntPtr _, uint unIPClient, IntPtr pvAuthBlob, uint cubAuthBlobSize, IntPtr pSteamIDUser)
+        {
+            return SteamEmulator.SteamGameServer.SendUserConnectAndAuthenticate(unIPClient, pvAuthBlob, cubAuthBlobSize, pSteamIDUser);
+        }
+
+        public IntPtr CreateUnauthenticatedUserConnection(IntPtr _, IntPtr pSteamID)
+        {
+            return NativeSteamId.Write(pSteamID, SteamEmulator.SteamGameServer.CreateUnauthenticatedUserConnection());
+        }
+
+        public void SendUserDisconnect(IntPtr _, ulong steamIDUser)
+        {
+            SteamEmulator.SteamGameServer.SendUserDisconnect(steamIDUser);
+        }
+
+        public bool BUpdateUserData(IntPtr _, ulong steamIDUser, IntPtr pchPlayerName, uint uScore)
+        {
+            SteamEmulator.Write("SteamGameServer009", $"BUpdateUserData name=0x{pchPlayerName.ToInt64():X}");
+            return SteamEmulator.SteamGameServer.BUpdateUserData(steamIDUser, ReadAnsi(pchPlayerName), uScore);
+        }
+
+        public bool BSetServerType(
+            IntPtr _,
+            uint unServerFlags,
+            uint unGameIP,
+            ushort unGamePort,
+            ushort unSpectatorPort,
+            ushort usQueryPort,
+            IntPtr pchGameDir,
+            IntPtr pchVersion,
+            bool bLANMode)
+        {
+            SteamEmulator.Write(
+                "SteamGameServer009",
+                $"BSetServerType flags={unServerFlags} ip={unGameIP} gamePort={unGamePort} spectatorPort={unSpectatorPort} queryPort={usQueryPort} gameDir=0x{pchGameDir.ToInt64():X} version=0x{pchVersion.ToInt64():X} lan={bLANMode}");
+            bool result = SteamEmulator.SteamGameServer.InitGameServer(
+                unGameIP,
+                unGamePort,
+                usQueryPort,
+                unServerFlags,
+                SteamEmulator.InternalAppId,
+                ReadAnsi(pchVersion));
+            SteamEmulator.SteamGameServer.SetModDir(ReadAnsi(pchGameDir));
+            SteamEmulator.SteamGameServer.SetSpectatorPort(unSpectatorPort);
+            return result;
+        }
+
+        public void UpdateServerStatus(
+            IntPtr _,
+            int cPlayers,
+            int cPlayersMax,
+            int cBotPlayers,
+            IntPtr pchServerName,
+            IntPtr pSpectatorServerName,
+            IntPtr pchMapName)
+        {
+            SteamEmulator.Write(
+                "SteamGameServer009",
+                $"UpdateServerStatus serverName=0x{pchServerName.ToInt64():X} spectatorName=0x{pSpectatorServerName.ToInt64():X} map=0x{pchMapName.ToInt64():X}");
+            SteamEmulator.SteamGameServer.SetMaxPlayerCount(cPlayersMax);
+            SteamEmulator.SteamGameServer.SetBotPlayerCount(cBotPlayers);
+            SteamEmulator.SteamGameServer.SetServerName(ReadAnsi(pchServerName));
+            SteamEmulator.SteamGameServer.SetSpectatorServerName(ReadAnsi(pSpectatorServerName));
+            SteamEmulator.SteamGameServer.SetMapName(ReadAnsi(pchMapName));
+        }
+
+        public void UpdateSpectatorPort(IntPtr _, ushort unSpectatorPort)
+        {
+            SteamEmulator.SteamGameServer.SetSpectatorPort(unSpectatorPort);
+        }
+
+        public void SetGameType(IntPtr _, IntPtr pchGameType)
+        {
+            SteamEmulator.Write("SteamGameServer009", $"SetGameType value=0x{pchGameType.ToInt64():X}");
+            SteamEmulator.SteamGameServer.SetGameTags(ReadAnsi(pchGameType));
+        }
+
+        public bool BGetUserAchievementStatus(IntPtr _, ulong steamID, IntPtr pchAchievementName)
+        {
+            SteamEmulator.Write("SteamGameServer009", $"BGetUserAchievementStatus name=0x{pchAchievementName.ToInt64():X}");
+            return false;
+        }
+
+        public void GetGameplayStats(IntPtr _)
+        {
+            SteamEmulator.SteamGameServer.GetGameplayStats();
+        }
+
+        public bool RequestUserGroupStatus(IntPtr _, ulong steamIDUser, ulong steamIDGroup)
+        {
+            return SteamEmulator.SteamGameServer.RequestUserGroupStatus(steamIDUser, steamIDGroup);
+        }
+
+        public uint GetPublicIP_old(IntPtr _)
+        {
+            return SteamEmulator.SteamGameServer.GetPublicIP_old();
+        }
+
+        public void SetGameData(IntPtr _, IntPtr pchGameData)
+        {
+            SteamEmulator.Write("SteamGameServer009", $"SetGameData value=0x{pchGameData.ToInt64():X}");
+            SteamEmulator.SteamGameServer.SetGameData(ReadAnsi(pchGameData));
+        }
+
+        public int UserHasLicenseForApp(IntPtr _, ulong steamID, uint appID)
+        {
+            return SteamEmulator.SteamGameServer.UserHasLicenseForApp(steamID, appID);
+        }
+
+        private static string ReadAnsi(IntPtr value)
+        {
+            long address = value.ToInt64();
+            if (address == 0)
+            {
+                return string.Empty;
+            }
+            if (address > 0 && address < 0x10000)
+            {
+                return $"<invalid:0x{address:X}>";
+            }
+
+            try
+            {
+                return Marshal.PtrToStringAnsi(value) ?? string.Empty;
+            }
+            catch
+            {
+                return $"<invalid:0x{address:X}>";
+            }
+        }
+    }
+}

--- a/steam_api/Steamworks/Interfaces/SteamMasterServerUpdater/SteamMasterServerUpdater001.cs
+++ b/steam_api/Steamworks/Interfaces/SteamMasterServerUpdater/SteamMasterServerUpdater001.cs
@@ -1,0 +1,95 @@
+using System;
+
+namespace SKYNET.Steamworks.Interfaces
+{
+    /// <summary>Legacy master-server updater ABI used by Left 4 Dead.</summary>
+    [Interface("SteamMasterServerUpdater001")]
+    [Interface("SteamMasterServerUpdater002")]
+    public class SteamMasterServerUpdater001 : ISteamInterface
+    {
+        public void SetActive(IntPtr _, bool bActive)
+        {
+            SteamEmulator.SteamMasterServerUpdater.SetActive(bActive);
+        }
+
+        public void SetHeartbeatInterval(IntPtr _, int iHeartbeatInterval)
+        {
+            SteamEmulator.SteamMasterServerUpdater.SetHeartbeatInterval(iHeartbeatInterval);
+        }
+
+        public bool HandleIncomingPacket(IntPtr _, IntPtr pData, int cbData, uint srcIP, uint srcPort)
+        {
+            return SteamEmulator.SteamMasterServerUpdater.HandleIncomingPacket(pData, cbData, srcIP, srcPort);
+        }
+
+        public int GetNextOutgoingPacket(IntPtr _, IntPtr pOut, int cbMaxOut, IntPtr pNetAdr, IntPtr pPort)
+        {
+            return SteamEmulator.SteamMasterServerUpdater.GetNextOutgoingPacket(pOut, cbMaxOut, 0, 0);
+        }
+
+        public void SetBasicServerData(
+            IntPtr _,
+            uint nProtocolVersion,
+            bool bDedicatedServer,
+            string pRegionName,
+            string pProductName,
+            uint nMaxReportedClients,
+            bool bPasswordProtected,
+            string pGameDescription)
+        {
+            SteamEmulator.SteamMasterServerUpdater.SetBasicServerData(
+                nProtocolVersion,
+                bDedicatedServer,
+                pRegionName,
+                pProductName,
+                nMaxReportedClients,
+                bPasswordProtected,
+                pGameDescription);
+        }
+
+        public void ClearAllKeyValues(IntPtr _)
+        {
+            SteamEmulator.SteamMasterServerUpdater.ClearAllKeyValues();
+        }
+
+        public void SetKeyValue(IntPtr _, string pKey, string pValue)
+        {
+            SteamEmulator.SteamMasterServerUpdater.SetKeyValue(pKey, pValue);
+        }
+
+        public void NotifyShutdown(IntPtr _)
+        {
+            SteamEmulator.SteamMasterServerUpdater.NotifyShutdown();
+        }
+
+        public bool WasRestartRequested(IntPtr _)
+        {
+            return SteamEmulator.SteamMasterServerUpdater.WasRestartRequested();
+        }
+
+        public void ForceHeartbeat(IntPtr _)
+        {
+            SteamEmulator.SteamMasterServerUpdater.ForceHeartbeat();
+        }
+
+        public bool AddMasterServer(IntPtr _, string pServerAddress)
+        {
+            return SteamEmulator.SteamMasterServerUpdater.AddMasterServer(pServerAddress);
+        }
+
+        public bool RemoveMasterServer(IntPtr _, string pServerAddress)
+        {
+            return SteamEmulator.SteamMasterServerUpdater.RemoveMasterServer(pServerAddress);
+        }
+
+        public int GetNumMasterServers(IntPtr _)
+        {
+            return SteamEmulator.SteamMasterServerUpdater.GetNumMasterServers();
+        }
+
+        public int GetMasterServerAddress(IntPtr _, int iServer, IntPtr pOut, int outBufferSize)
+        {
+            return 0;
+        }
+    }
+}

--- a/steam_api/Steamworks/Interfaces/SteamMatchmaking/SteamMatchmaking007.cs
+++ b/steam_api/Steamworks/Interfaces/SteamMatchmaking/SteamMatchmaking007.cs
@@ -1,0 +1,113 @@
+using System;
+using SKYNET.Helpers;
+
+namespace SKYNET.Steamworks.Interfaces
+{
+    /// <summary>
+    /// Legacy ISteamMatchmaking ABI used by Left 4 Dead. Version 007 predates
+    /// the distance and result-count lobby filters introduced in version 008.
+    /// </summary>
+    [Interface("SteamMatchMaking007")]
+    public class SteamMatchMaking007 : ISteamInterface
+    {
+        public int GetFavoriteGameCount(IntPtr _) => SteamEmulator.SteamMatchmaking.GetFavoriteGameCount();
+
+        public bool GetFavoriteGame(IntPtr _, int iGame, IntPtr pnAppID, IntPtr pnIP, IntPtr pnConnPort, IntPtr pnQueryPort, IntPtr punFlags, IntPtr pRTime32LastPlayedOnServer) =>
+            SteamEmulator.SteamMatchmaking.GetFavoriteGame(iGame, pnAppID, pnIP, pnConnPort, pnQueryPort, punFlags, pRTime32LastPlayedOnServer);
+
+        public int AddFavoriteGame(IntPtr _, uint nAppID, uint nIP, ushort nConnPort, ushort nQueryPort, uint unFlags, uint rTime32LastPlayedOnServer) =>
+            SteamEmulator.SteamMatchmaking.AddFavoriteGame(nAppID, nIP, nConnPort, nQueryPort, unFlags, rTime32LastPlayedOnServer);
+
+        public bool RemoveFavoriteGame(IntPtr _, uint nAppID, uint nIP, ushort nConnPort, ushort nQueryPort, uint unFlags) =>
+            SteamEmulator.SteamMatchmaking.RemoveFavoriteGame(nAppID, nIP, nConnPort, nQueryPort, unFlags);
+
+        public ulong RequestLobbyList(IntPtr _) => SteamEmulator.SteamMatchmaking.RequestLobbyList();
+
+        public void AddRequestLobbyListStringFilter(IntPtr _, string pchKeyToMatch, string pchValueToMatch, int eComparisonType) =>
+            SteamEmulator.SteamMatchmaking.AddRequestLobbyListStringFilter(pchKeyToMatch, pchValueToMatch, eComparisonType);
+
+        public void AddRequestLobbyListNumericalFilter(IntPtr _, string pchKeyToMatch, int nValueToMatch, int eComparisonType) =>
+            SteamEmulator.SteamMatchmaking.AddRequestLobbyListNumericalFilter(pchKeyToMatch, nValueToMatch, eComparisonType);
+
+        public void AddRequestLobbyListNearValueFilter(IntPtr _, string pchKeyToMatch, int nValueToBeCloseTo) =>
+            SteamEmulator.SteamMatchmaking.AddRequestLobbyListNearValueFilter(pchKeyToMatch, nValueToBeCloseTo);
+
+        public void AddRequestLobbyListFilterSlotsAvailable(IntPtr _, int nSlotsAvailable) =>
+            SteamEmulator.SteamMatchmaking.AddRequestLobbyListFilterSlotsAvailable(nSlotsAvailable);
+
+        public IntPtr GetLobbyByIndex(IntPtr _, IntPtr ret, int iLobby) =>
+            NativeSteamId.Write(ret, SteamEmulator.SteamMatchmaking.GetLobbyByIndex(iLobby));
+
+        public ulong CreateLobby(IntPtr _, int eLobbyType, int cMaxMembers) =>
+            SteamEmulator.SteamMatchmaking.CreateLobby(eLobbyType, cMaxMembers);
+
+        public ulong JoinLobby(IntPtr _, ulong steamIDLobby) =>
+            SteamEmulator.SteamMatchmaking.JoinLobby(steamIDLobby);
+
+        public void LeaveLobby(IntPtr _, ulong steamIDLobby) =>
+            SteamEmulator.SteamMatchmaking.LeaveLobby(steamIDLobby);
+
+        public bool InviteUserToLobby(IntPtr _, ulong steamIDLobby, ulong steamIDInvitee) =>
+            SteamEmulator.SteamMatchmaking.InviteUserToLobby(steamIDLobby, steamIDInvitee);
+
+        public int GetNumLobbyMembers(IntPtr _, ulong steamIDLobby) =>
+            SteamEmulator.SteamMatchmaking.GetNumLobbyMembers(steamIDLobby);
+
+        public IntPtr GetLobbyMemberByIndex(IntPtr _, IntPtr ret, ulong steamIDLobby, int iMember) =>
+            NativeSteamId.Write(ret, SteamEmulator.SteamMatchmaking.GetLobbyMemberByIndex(steamIDLobby, iMember));
+
+        public IntPtr GetLobbyData(IntPtr _, ulong steamIDLobby, string pchKey) =>
+            NativeStringCache.ToUtf8Ptr(SteamEmulator.SteamMatchmaking.GetLobbyData(steamIDLobby, pchKey));
+
+        public bool SetLobbyData(IntPtr _, ulong steamIDLobby, string pchKey, string pchValue) =>
+            SteamEmulator.SteamMatchmaking.SetLobbyData(steamIDLobby, pchKey, pchValue);
+
+        public int GetLobbyDataCount(IntPtr _, ulong steamIDLobby) =>
+            SteamEmulator.SteamMatchmaking.GetLobbyDataCount(steamIDLobby);
+
+        public bool GetLobbyDataByIndex(IntPtr _, ulong steamIDLobby, int iLobbyData, IntPtr pchKey, int cchKeyBufferSize, IntPtr pchValue, int cchValueBufferSize) =>
+            SteamEmulator.SteamMatchmaking.GetLobbyDataByIndex(steamIDLobby, iLobbyData, pchKey, cchKeyBufferSize, pchValue, cchValueBufferSize);
+
+        public bool DeleteLobbyData(IntPtr _, ulong steamIDLobby, string pchKey) =>
+            SteamEmulator.SteamMatchmaking.DeleteLobbyData(steamIDLobby, pchKey);
+
+        public IntPtr GetLobbyMemberData(IntPtr _, ulong steamIDLobby, ulong steamIDUser, string pchKey) =>
+            NativeStringCache.ToUtf8Ptr(SteamEmulator.SteamMatchmaking.GetLobbyMemberData(steamIDLobby, steamIDUser, pchKey));
+
+        public void SetLobbyMemberData(IntPtr _, ulong steamIDLobby, string pchKey, string pchValue) =>
+            SteamEmulator.SteamMatchmaking.SetLobbyMemberData(steamIDLobby, pchKey, pchValue);
+
+        public bool SendLobbyChatMsg(IntPtr _, ulong steamIDLobby, IntPtr pvMsgBody, int cubMsgBody) =>
+            SteamEmulator.SteamMatchmaking.SendLobbyChatMsg(steamIDLobby, pvMsgBody, cubMsgBody);
+
+        public int GetLobbyChatEntry(IntPtr _, ulong steamIDLobby, int iChatID, IntPtr pSteamIDUser, IntPtr pvData, int cubData, IntPtr peChatEntryType) =>
+            SteamEmulator.SteamMatchmaking.GetLobbyChatEntry(steamIDLobby, iChatID, pSteamIDUser, pvData, cubData, peChatEntryType);
+
+        public bool RequestLobbyData(IntPtr _, ulong steamIDLobby) =>
+            SteamEmulator.SteamMatchmaking.RequestLobbyData(steamIDLobby);
+
+        public void SetLobbyGameServer(IntPtr _, ulong steamIDLobby, uint unGameServerIP, ushort unGameServerPort, ulong steamIDGameServer) =>
+            SteamEmulator.SteamMatchmaking.SetLobbyGameServer(steamIDLobby, unGameServerIP, unGameServerPort, steamIDGameServer);
+
+        public bool GetLobbyGameServer(IntPtr _, ulong steamIDLobby, IntPtr punGameServerIP, IntPtr punGameServerPort, IntPtr psteamIDGameServer) =>
+            SteamEmulator.SteamMatchmaking.GetLobbyGameServer(steamIDLobby, punGameServerIP, punGameServerPort, psteamIDGameServer);
+
+        public bool SetLobbyMemberLimit(IntPtr _, ulong steamIDLobby, int cMaxMembers) =>
+            SteamEmulator.SteamMatchmaking.SetLobbyMemberLimit(steamIDLobby, cMaxMembers);
+
+        public int GetLobbyMemberLimit(IntPtr _, ulong steamIDLobby) =>
+            SteamEmulator.SteamMatchmaking.GetLobbyMemberLimit(steamIDLobby);
+
+        public bool SetLobbyType(IntPtr _, ulong steamIDLobby, int eLobbyType) =>
+            SteamEmulator.SteamMatchmaking.SetLobbyType(steamIDLobby, eLobbyType);
+
+        public bool SetLobbyJoinable(IntPtr _, ulong steamIDLobby, bool bLobbyJoinable) =>
+            SteamEmulator.SteamMatchmaking.SetLobbyJoinable(steamIDLobby, bLobbyJoinable);
+
+        public IntPtr GetLobbyOwner(IntPtr _, IntPtr ret, ulong steamIDLobby) =>
+            NativeSteamId.Write(ret, SteamEmulator.SteamMatchmaking.GetLobbyOwner(steamIDLobby));
+
+        public bool SetLobbyOwner(IntPtr _, ulong steamIDLobby, ulong steamIDNewOwner) =>
+            SteamEmulator.SteamMatchmaking.SetLobbyOwner(steamIDLobby, steamIDNewOwner);
+    }
+}

--- a/steam_api/Steamworks/Interfaces/SteamNetworking/SteamNetworking003.cs
+++ b/steam_api/Steamworks/Interfaces/SteamNetworking/SteamNetworking003.cs
@@ -1,0 +1,109 @@
+using System;
+
+namespace SKYNET.Steamworks.Interfaces
+{
+    /// <summary>Legacy ISteamNetworking ABI used by Left 4 Dead.</summary>
+    [Interface("SteamNetworking003")]
+    public class SteamNetworking003 : ISteamInterface
+    {
+        public bool SendP2PPacket(IntPtr _, ulong steamIDRemote, IntPtr pubData, uint cubData, int eP2PSendType)
+        {
+            return SteamEmulator.SteamNetworking.SendP2PPacket(steamIDRemote, pubData, cubData, eP2PSendType, 0);
+        }
+
+        public bool IsP2PPacketAvailable(IntPtr _, ref uint pcubMsgSize)
+        {
+            return SteamEmulator.SteamNetworking.IsP2PPacketAvailable(ref pcubMsgSize, 0);
+        }
+
+        public bool ReadP2PPacket(IntPtr _, IntPtr pubDest, uint cubDest, ref uint pcubMsgSize, ref ulong psteamIDRemote)
+        {
+            return SteamEmulator.SteamNetworking.ReadP2PPacket(pubDest, cubDest, ref pcubMsgSize, ref psteamIDRemote, 0);
+        }
+
+        public bool AcceptP2PSessionWithUser(IntPtr _, ulong steamIDRemote)
+        {
+            return SteamEmulator.SteamNetworking.AcceptP2PSessionWithUser(steamIDRemote);
+        }
+
+        public bool CloseP2PSessionWithUser(IntPtr _, ulong steamIDRemote)
+        {
+            return SteamEmulator.SteamNetworking.CloseP2PSessionWithUser(steamIDRemote);
+        }
+
+        public bool GetP2PSessionState(IntPtr _, ulong steamIDRemote, IntPtr pConnectionState)
+        {
+            return SteamEmulator.SteamNetworking.GetP2PSessionState(steamIDRemote, pConnectionState);
+        }
+
+        public uint CreateListenSocket(IntPtr _, int nVirtualP2PPort, uint nIP, ushort nPort, bool bAllowUseOfPacketRelay)
+        {
+            return SteamEmulator.SteamNetworking.CreateListenSocket(nVirtualP2PPort, nIP, nPort, bAllowUseOfPacketRelay);
+        }
+
+        public uint CreateP2PConnectionSocket(IntPtr _, ulong steamIDTarget, int nVirtualPort, int nTimeoutSec, bool bAllowUseOfPacketRelay)
+        {
+            return SteamEmulator.SteamNetworking.CreateP2PConnectionSocket(steamIDTarget, nVirtualPort, nTimeoutSec, bAllowUseOfPacketRelay);
+        }
+
+        public uint CreateConnectionSocket(IntPtr _, uint nIP, ushort nPort, int nTimeoutSec)
+        {
+            return SteamEmulator.SteamNetworking.CreateConnectionSocket(nIP, nPort, nTimeoutSec);
+        }
+
+        public bool DestroySocket(IntPtr _, uint hSocket, bool bNotifyRemoteEnd)
+        {
+            return SteamEmulator.SteamNetworking.DestroySocket(hSocket, bNotifyRemoteEnd);
+        }
+
+        public bool DestroyListenSocket(IntPtr _, uint hSocket, bool bNotifyRemoteEnd)
+        {
+            return SteamEmulator.SteamNetworking.DestroyListenSocket(hSocket, bNotifyRemoteEnd);
+        }
+
+        public bool SendDataOnSocket(IntPtr _, uint hSocket, IntPtr pubData, uint cubData, bool bReliable)
+        {
+            return SteamEmulator.SteamNetworking.SendDataOnSocket(hSocket, pubData, cubData, bReliable);
+        }
+
+        public bool IsDataAvailableOnSocket(IntPtr _, uint hSocket, IntPtr pcubMsgSize)
+        {
+            return SteamEmulator.SteamNetworking.IsDataAvailableOnSocket(hSocket, pcubMsgSize);
+        }
+
+        public bool RetrieveDataFromSocket(IntPtr _, uint hSocket, IntPtr pubDest, uint cubDest, IntPtr pcubMsgSize)
+        {
+            return SteamEmulator.SteamNetworking.RetrieveDataFromSocket(hSocket, pubDest, cubDest, pcubMsgSize);
+        }
+
+        public bool IsDataAvailable(IntPtr _, uint hListenSocket, IntPtr pcubMsgSize, IntPtr phSocket)
+        {
+            return SteamEmulator.SteamNetworking.IsDataAvailable(hListenSocket, pcubMsgSize, phSocket);
+        }
+
+        public bool RetrieveData(IntPtr _, uint hListenSocket, IntPtr pubDest, uint cubDest, IntPtr pcubMsgSize, IntPtr phSocket)
+        {
+            return SteamEmulator.SteamNetworking.RetrieveData(hListenSocket, pubDest, cubDest, pcubMsgSize, phSocket);
+        }
+
+        public bool GetSocketInfo(IntPtr _, uint hSocket, IntPtr pSteamIDRemote, IntPtr peSocketStatus, IntPtr punIPRemote, IntPtr punPortRemote)
+        {
+            return SteamEmulator.SteamNetworking.GetSocketInfo(hSocket, pSteamIDRemote, peSocketStatus, punIPRemote, punPortRemote);
+        }
+
+        public bool GetListenSocketInfo(IntPtr _, uint hListenSocket, IntPtr pnIP, IntPtr pnPort)
+        {
+            return SteamEmulator.SteamNetworking.GetListenSocketInfo(hListenSocket, pnIP, pnPort);
+        }
+
+        public int GetSocketConnectionType(IntPtr _, uint hSocket)
+        {
+            return SteamEmulator.SteamNetworking.GetSocketConnectionType(hSocket);
+        }
+
+        public int GetMaxPacketSize(IntPtr _, uint hSocket)
+        {
+            return SteamEmulator.SteamNetworking.GetMaxPacketSize(hSocket);
+        }
+    }
+}

--- a/steam_api/Steamworks/Interfaces/SteamRemoteStorage/SteamRemoteStorage002.cs
+++ b/steam_api/Steamworks/Interfaces/SteamRemoteStorage/SteamRemoteStorage002.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace SKYNET.Steamworks.Interfaces
+{
+    /// <summary>Legacy ISteamRemoteStorage ABI used by Left 4 Dead.</summary>
+    [Interface("STEAMREMOTESTORAGE_INTERFACE_VERSION002")]
+    public class SteamRemoteStorage002 : ISteamInterface
+    {
+        public bool FileWrite(IntPtr _, string pchFile, IntPtr pvData, int cubData)
+        {
+            return SteamEmulator.SteamRemoteStorage.FileWrite(pchFile, pvData, cubData);
+        }
+
+        public int GetFileSize(IntPtr _, string pchFile)
+        {
+            return SteamEmulator.SteamRemoteStorage.GetFileSize(pchFile);
+        }
+
+        public int FileRead(IntPtr _, string pchFile, IntPtr pvData, int cubDataToRead)
+        {
+            return SteamEmulator.SteamRemoteStorage.FileRead(pchFile, pvData, cubDataToRead);
+        }
+
+        public bool FileExists(IntPtr _, string pchFile)
+        {
+            return SteamEmulator.SteamRemoteStorage.FileExists(pchFile);
+        }
+
+        public int GetFileCount(IntPtr _)
+        {
+            return SteamEmulator.SteamRemoteStorage.GetFileCount();
+        }
+
+        public string GetFileNameAndSize(IntPtr _, int iFile, ref int pnFileSizeInBytes)
+        {
+            return SteamEmulator.SteamRemoteStorage.GetFileNameAndSize(iFile, ref pnFileSizeInBytes);
+        }
+
+        public bool GetQuota(IntPtr _, IntPtr pnTotalBytes, IntPtr puAvailableBytes)
+        {
+            ulong total = 0;
+            ulong available = 0;
+            bool result = SteamEmulator.SteamRemoteStorage.GetQuota(ref total, ref available);
+
+            if (pnTotalBytes != IntPtr.Zero)
+            {
+                Marshal.WriteInt32(pnTotalBytes, unchecked((int)Math.Min(total, int.MaxValue)));
+            }
+            if (puAvailableBytes != IntPtr.Zero)
+            {
+                Marshal.WriteInt32(puAvailableBytes, unchecked((int)Math.Min(available, int.MaxValue)));
+            }
+
+            return result;
+        }
+    }
+}

--- a/steam_api/Steamworks/Interfaces/SteamUGC/SteamUGC017Generated.cs
+++ b/steam_api/Steamworks/Interfaces/SteamUGC/SteamUGC017Generated.cs
@@ -1,0 +1,100 @@
+using System;
+
+namespace SKYNET.Steamworks.Interfaces
+{
+    [Interface("STEAMUGC_INTERFACE_VERSION017")]
+    [MsvcVTableOverload("CreateQueryAllUGCRequestPage", "CreateQueryAllUGCRequestCursor")]
+    [MsvcVTableOverload("GetQueryUGCKeyValueTag", "GetQueryFirstUGCKeyValueTag")]
+    public class SteamUGC017Generated : ISteamInterface
+    {
+        public ulong CreateQueryUserUGCRequest(IntPtr _, uint arg0, int arg1, int arg2, int arg3, uint arg4, uint arg5, uint arg6) { return 0; }
+        public ulong CreateQueryAllUGCRequestPage(IntPtr _, int arg0, int arg1, uint arg2, uint arg3, uint arg4) { return 0; }
+        public ulong CreateQueryAllUGCRequestCursor(IntPtr _, int arg0, int arg1, uint arg2, uint arg3, IntPtr arg4) { return 0; }
+        public ulong CreateQueryUGCDetailsRequest(IntPtr _, IntPtr arg0, uint arg1) { return SteamEmulator.SteamUGC.CreateQueryUGCDetailsRequest(arg0, arg1); }
+        public ulong SendQueryUGCRequest(IntPtr _, ulong arg0) { return 0; }
+        public bool GetQueryUGCResult_old(IntPtr _, ulong arg0, uint arg1, IntPtr arg2) { return false; }
+        public uint GetQueryUGCNumTags(IntPtr _, ulong arg0, uint arg1) { return 0; }
+        public bool GetQueryUGCTag(IntPtr _, ulong arg0, uint arg1, uint arg2, IntPtr arg3, uint arg4) { return false; }
+        public bool GetQueryUGCTagDisplayName(IntPtr _, ulong arg0, uint arg1, uint arg2, IntPtr arg3, uint arg4) { return false; }
+        public bool GetQueryUGCPreviewURL(IntPtr _, ulong arg0, uint arg1, IntPtr arg2, uint arg3) { return false; }
+        public bool GetQueryUGCMetadata(IntPtr _, ulong arg0, uint arg1, IntPtr arg2, uint arg3) { return false; }
+        public bool GetQueryUGCChildren(IntPtr _, ulong arg0, uint arg1, IntPtr arg2, uint arg3) { return false; }
+        public bool GetQueryUGCStatistic(IntPtr _, ulong arg0, uint arg1, int arg2, IntPtr arg3) { return false; }
+        public uint GetQueryUGCNumAdditionalPreviews(IntPtr _, ulong arg0, uint arg1) { return 0; }
+        public bool GetQueryUGCAdditionalPreview(IntPtr _, ulong arg0, uint arg1, uint arg2, IntPtr arg3, uint arg4, IntPtr arg5, uint arg6, IntPtr arg7) { return false; }
+        public uint GetQueryUGCNumKeyValueTags(IntPtr _, ulong arg0, uint arg1) { return 0; }
+        public bool GetQueryUGCKeyValueTag(IntPtr _, ulong arg0, uint arg1, uint arg2, IntPtr arg3, uint arg4, IntPtr arg5, uint arg6) { return false; }
+        public bool GetQueryFirstUGCKeyValueTag(IntPtr _, ulong arg0, uint arg1, IntPtr arg2, IntPtr arg3, uint arg4) { return false; }
+        public uint GetQueryUGCContentDescriptors(IntPtr _, ulong arg0, uint arg1, IntPtr arg2, uint arg3) { return 0; }
+        public bool ReleaseQueryUGCRequest(IntPtr _, ulong arg0) { return false; }
+        public bool AddRequiredTag(IntPtr _, ulong arg0, IntPtr arg1) { return false; }
+        public bool AddRequiredTagGroup(IntPtr _, ulong arg0, IntPtr arg1) { return false; }
+        public bool AddExcludedTag(IntPtr _, ulong arg0, IntPtr arg1) { return false; }
+        public bool SetReturnOnlyIDs(IntPtr _, ulong arg0, bool arg1) { return false; }
+        public bool SetReturnKeyValueTags(IntPtr _, ulong arg0, bool arg1) { return false; }
+        public bool SetReturnLongDescription(IntPtr _, ulong arg0, bool arg1) { return false; }
+        public bool SetReturnMetadata(IntPtr _, ulong arg0, bool arg1) { return false; }
+        public bool SetReturnChildren(IntPtr _, ulong arg0, bool arg1) { return false; }
+        public bool SetReturnAdditionalPreviews(IntPtr _, ulong arg0, bool arg1) { return false; }
+        public bool SetReturnTotalOnly(IntPtr _, ulong arg0, bool arg1) { return false; }
+        public bool SetReturnPlaytimeStats(IntPtr _, ulong arg0, uint arg1) { return false; }
+        public bool SetLanguage(IntPtr _, ulong arg0, IntPtr arg1) { return false; }
+        public bool SetAllowCachedResponse(IntPtr _, ulong arg0, uint arg1) { return false; }
+        public bool SetCloudFileNameFilter(IntPtr _, ulong arg0, IntPtr arg1) { return false; }
+        public bool SetMatchAnyTag(IntPtr _, ulong arg0, bool arg1) { return false; }
+        public bool SetSearchText(IntPtr _, ulong arg0, IntPtr arg1) { return false; }
+        public bool SetRankedByTrendDays(IntPtr _, ulong arg0, uint arg1) { return false; }
+        public bool SetTimeCreatedDateRange(IntPtr _, ulong arg0, uint arg1, uint arg2) { return false; }
+        public bool SetTimeUpdatedDateRange(IntPtr _, ulong arg0, uint arg1, uint arg2) { return false; }
+        public bool AddRequiredKeyValueTag(IntPtr _, ulong arg0, IntPtr arg1, IntPtr arg2) { return false; }
+        public ulong RequestUGCDetails_old(IntPtr _, ulong arg0, uint arg1) { return SteamEmulator.SteamUGC.RequestUGCDetails(arg0, arg1); }
+        public ulong CreateItem(IntPtr _, uint arg0, int arg1) { return 0; }
+        public ulong StartItemUpdate(IntPtr _, uint arg0, ulong arg1) { return 0; }
+        public bool SetItemTitle(IntPtr _, ulong arg0, IntPtr arg1) { return false; }
+        public bool SetItemDescription(IntPtr _, ulong arg0, IntPtr arg1) { return false; }
+        public bool SetItemUpdateLanguage(IntPtr _, ulong arg0, IntPtr arg1) { return false; }
+        public bool SetItemMetadata(IntPtr _, ulong arg0, IntPtr arg1) { return false; }
+        public bool SetItemVisibility(IntPtr _, ulong arg0, int arg1) { return false; }
+        public bool SetItemTags(IntPtr _, ulong arg0, IntPtr arg1) { return false; }
+        public bool SetItemContent(IntPtr _, ulong arg0, IntPtr arg1) { return false; }
+        public bool SetItemPreview(IntPtr _, ulong arg0, IntPtr arg1) { return false; }
+        public bool SetAllowLegacyUpload(IntPtr _, ulong arg0, bool arg1) { return false; }
+        public bool RemoveAllItemKeyValueTags(IntPtr _, ulong arg0) { return false; }
+        public bool RemoveItemKeyValueTags(IntPtr _, ulong arg0, IntPtr arg1) { return false; }
+        public bool AddItemKeyValueTag(IntPtr _, ulong arg0, IntPtr arg1, IntPtr arg2) { return false; }
+        public bool AddItemPreviewFile(IntPtr _, ulong arg0, IntPtr arg1, int arg2) { return false; }
+        public bool AddItemPreviewVideo(IntPtr _, ulong arg0, IntPtr arg1) { return false; }
+        public bool UpdateItemPreviewFile(IntPtr _, ulong arg0, uint arg1, IntPtr arg2) { return false; }
+        public bool UpdateItemPreviewVideo(IntPtr _, ulong arg0, uint arg1, IntPtr arg2) { return false; }
+        public bool RemoveItemPreview(IntPtr _, ulong arg0, uint arg1) { return false; }
+        public bool AddContentDescriptor(IntPtr _, ulong arg0, int arg1) { return false; }
+        public bool RemoveContentDescriptor(IntPtr _, ulong arg0, int arg1) { return false; }
+        public ulong SubmitItemUpdate(IntPtr _, ulong arg0, IntPtr arg1) { return 0; }
+        public int GetItemUpdateProgress(IntPtr _, ulong arg0, IntPtr arg1, IntPtr arg2) { return 0; }
+        public ulong SetUserItemVote(IntPtr _, ulong arg0, bool arg1) { return 0; }
+        public ulong GetUserItemVote(IntPtr _, ulong arg0) { return 0; }
+        public ulong AddItemToFavorites(IntPtr _, uint arg0, ulong arg1) { return 0; }
+        public ulong RemoveItemFromFavorites(IntPtr _, uint arg0, ulong arg1) { return 0; }
+        public ulong SubscribeItem(IntPtr _, ulong arg0) { return 0; }
+        public ulong UnsubscribeItem(IntPtr _, ulong arg0) { return 0; }
+        public uint GetNumSubscribedItems(IntPtr _) { return SteamEmulator.SteamUGC.GetNumSubscribedItems(); }
+        public uint GetSubscribedItems(IntPtr _, IntPtr arg0, uint arg1) { return SteamEmulator.SteamUGC.GetSubscribedItems(arg0, arg1); }
+        public uint GetItemState(IntPtr _, ulong arg0) { return SteamEmulator.SteamUGC.GetItemState(arg0); }
+        public bool GetItemInstallInfo(IntPtr _, ulong arg0, IntPtr arg1, IntPtr arg2, uint arg3, IntPtr arg4) { return SteamEmulator.SteamUGC.GetItemInstallInfo(arg0, arg1, arg2, arg3, arg4); }
+        public bool GetItemDownloadInfo(IntPtr _, ulong arg0, IntPtr arg1, IntPtr arg2) { return false; }
+        public bool DownloadItem(IntPtr _, ulong arg0, bool arg1) { return false; }
+        public bool BInitWorkshopForGameServer(IntPtr _, uint arg0, IntPtr arg1) { return false; }
+        public void SuspendDownloads(IntPtr _, bool arg0) { }
+        public ulong StartPlaytimeTracking(IntPtr _, IntPtr arg0, uint arg1) { return 0; }
+        public ulong StopPlaytimeTracking(IntPtr _, IntPtr arg0, uint arg1) { return 0; }
+        public ulong StopPlaytimeTrackingForAllItems(IntPtr _) { return 0; }
+        public ulong AddDependency(IntPtr _, ulong arg0, ulong arg1) { return 0; }
+        public ulong RemoveDependency(IntPtr _, ulong arg0, ulong arg1) { return 0; }
+        public ulong AddAppDependency(IntPtr _, ulong arg0, uint arg1) { return 0; }
+        public ulong RemoveAppDependency(IntPtr _, ulong arg0, uint arg1) { return 0; }
+        public ulong GetAppDependencies(IntPtr _, ulong arg0) { return 0; }
+        public ulong DeleteItem(IntPtr _, ulong arg0) { return 0; }
+        public bool ShowWorkshopEULA(IntPtr _) { return false; }
+        public ulong GetWorkshopEULAStatus(IntPtr _) { return 0; }
+    }
+}

--- a/steam_api/Steamworks/Interfaces/SteamUser/SteamUser013.cs
+++ b/steam_api/Steamworks/Interfaces/SteamUser/SteamUser013.cs
@@ -1,0 +1,105 @@
+using System;
+using SKYNET.Helpers;
+
+using CGameID = System.UInt64;
+using HSteamUser = System.UInt32;
+
+namespace SKYNET.Steamworks.Interfaces
+{
+    /// <summary>
+    /// Legacy ISteamUser ABI used by the original Left 4 Dead Steamworks SDK.
+    /// SteamUser013 predates the configurable voice sample-rate arguments and
+    /// contains exactly 18 vtable slots, ending at UserHasLicenseForApp.
+    /// </summary>
+    [Interface("SteamUser013")]
+    public class SteamUser013 : ISteamInterface
+    {
+        private const uint LegacyVoiceSampleRate = 11025;
+
+        public HSteamUser GetHSteamUser(IntPtr _) => SteamEmulator.SteamUser.GetHSteamUser();
+        public bool BLoggedOn(IntPtr _) => SteamEmulator.SteamUser.BLoggedOn();
+        public IntPtr GetSteamID(IntPtr _, IntPtr pSteamID) => NativeSteamId.Write(pSteamID, SteamEmulator.SteamUser.GetSteamID());
+
+        public int InitiateGameConnection(
+            IntPtr _,
+            IntPtr pAuthBlob,
+            int cbMaxAuthBlob,
+            ulong steamIDGameServer,
+            uint unIPServer,
+            ushort usPortServer,
+            bool bSecure) =>
+            SteamEmulator.SteamUser.InitiateGameConnection(
+                pAuthBlob,
+                cbMaxAuthBlob,
+                steamIDGameServer,
+                unIPServer,
+                usPortServer,
+                bSecure);
+
+        public void TerminateGameConnection(IntPtr _, uint unIPServer, ushort usPortServer) =>
+            SteamEmulator.SteamUser.TerminateGameConnection(unIPServer, usPortServer);
+
+        public void TrackAppUsageEvent(IntPtr _, CGameID gameID, int eAppUsageEvent, string pchExtraInfo) =>
+            SteamEmulator.SteamUser.TrackAppUsageEvent(gameID, eAppUsageEvent, pchExtraInfo);
+
+        public bool GetUserDataFolder(IntPtr _, IntPtr pchBuffer, int cubBuffer) =>
+            SteamEmulator.SteamUser.GetUserDataFolder(pchBuffer, cubBuffer);
+
+        public void StartVoiceRecording(IntPtr _) => SteamEmulator.SteamUser.StartVoiceRecording();
+        public void StopVoiceRecording(IntPtr _) => SteamEmulator.SteamUser.StopVoiceRecording();
+
+        public EVoiceResult GetAvailableVoice(IntPtr _, IntPtr pcbCompressed, IntPtr pcbUncompressed) =>
+            SteamEmulator.SteamUser.GetAvailableVoice(
+                pcbCompressed,
+                pcbUncompressed,
+                LegacyVoiceSampleRate);
+
+        public EVoiceResult GetVoice(
+            IntPtr _,
+            bool bWantCompressed,
+            IntPtr pDestBuffer,
+            uint cbDestBufferSize,
+            IntPtr nBytesWritten,
+            bool bWantUncompressed,
+            IntPtr pUncompressedDestBuffer,
+            uint cbUncompressedDestBufferSize,
+            IntPtr nUncompressBytesWritten) =>
+            SteamEmulator.SteamUser.GetVoice(
+                bWantCompressed,
+                pDestBuffer,
+                cbDestBufferSize,
+                nBytesWritten,
+                bWantUncompressed,
+                pUncompressedDestBuffer,
+                cbUncompressedDestBufferSize,
+                nUncompressBytesWritten,
+                LegacyVoiceSampleRate);
+
+        public EVoiceResult DecompressVoice(
+            IntPtr _,
+            IntPtr pCompressed,
+            uint cbCompressed,
+            IntPtr pDestBuffer,
+            uint cbDestBufferSize,
+            IntPtr nBytesWritten) =>
+            SteamEmulator.SteamUser.DecompressVoice(
+                pCompressed,
+                cbCompressed,
+                pDestBuffer,
+                cbDestBufferSize,
+                nBytesWritten,
+                LegacyVoiceSampleRate);
+
+        public uint GetAuthSessionTicket(IntPtr _, IntPtr pTicket, int cbMaxTicket, ref uint pcbTicket) =>
+            SteamEmulator.SteamUser.GetAuthSessionTicket(pTicket, cbMaxTicket, out pcbTicket);
+
+        public int BeginAuthSession(IntPtr _, IntPtr pAuthTicket, int cbAuthTicket, ulong steamID) =>
+            SteamEmulator.SteamUser.BeginAuthSession(pAuthTicket, cbAuthTicket, steamID);
+
+        public void EndAuthSession(IntPtr _, ulong steamID) => SteamEmulator.SteamUser.EndAuthSession(steamID);
+        public void CancelAuthTicket(IntPtr _, uint hAuthTicket) => SteamEmulator.SteamUser.CancelAuthTicket(hAuthTicket);
+
+        public int UserHasLicenseForApp(IntPtr _, ulong steamID, uint appID) =>
+            SteamEmulator.SteamUser.UserHasLicenseForApp(steamID, appID);
+    }
+}

--- a/steam_api/Steamworks/Interfaces/SteamUserStats/SteamUserStats007.cs
+++ b/steam_api/Steamworks/Interfaces/SteamUserStats/SteamUserStats007.cs
@@ -1,0 +1,46 @@
+using System;
+using SKYNET.Helpers;
+
+using SteamAPICall_t = System.UInt64;
+
+namespace SKYNET.Steamworks.Interfaces
+{
+    /// <summary>Legacy ISteamUserStats ABI used by Left 4 Dead.</summary>
+    [Interface("STEAMUSERSTATS_INTERFACE_VERSION007")]
+    [MsvcVTableOverload("GetStatInt32", "GetStatFloat")]
+    [MsvcVTableOverload("SetStatInt32", "SetStatFloat")]
+    [MsvcVTableOverload("GetUserStatInt32", "GetUserStatFloat")]
+    public class SteamUserStats007 : ISteamInterface
+    {
+        public bool RequestCurrentStats(IntPtr _) => SteamEmulator.SteamUserStats.RequestCurrentStats();
+        public bool GetStatInt32(IntPtr _, string pchName, IntPtr pData) => SteamEmulator.SteamUserStats.GetStatInt32(pchName, pData);
+        public bool GetStatFloat(IntPtr _, string pchName, IntPtr pData) => SteamEmulator.SteamUserStats.GetStatFloat(pchName, pData);
+        public bool SetStatInt32(IntPtr _, string pchName, int nData) => SteamEmulator.SteamUserStats.SetStat(pchName, unchecked((uint)nData));
+        public bool SetStatFloat(IntPtr _, string pchName, float fData) => SteamEmulator.SteamUserStats.SetStat(pchName, fData);
+        public bool UpdateAvgRateStat(IntPtr _, string pchName, float flCountThisSession, double dSessionLength) => SteamEmulator.SteamUserStats.UpdateAvgRateStat(pchName, flCountThisSession, dSessionLength);
+        public bool GetAchievement(IntPtr _, string pchName, IntPtr pbAchieved) => SteamEmulator.SteamUserStats.GetAchievement(pchName, pbAchieved);
+        public bool SetAchievement(IntPtr _, string pchName) => SteamEmulator.SteamUserStats.SetAchievement(pchName);
+        public bool ClearAchievement(IntPtr _, string pchName) => SteamEmulator.SteamUserStats.ClearAchievement(pchName);
+        public bool GetAchievementAndUnlockTime(IntPtr _, string pchName, IntPtr pbAchieved, IntPtr punUnlockTime) => SteamEmulator.SteamUserStats.GetAchievementAndUnlockTime(pchName, pbAchieved, punUnlockTime);
+        public bool StoreStats(IntPtr _) => SteamEmulator.SteamUserStats.StoreStats();
+        public int GetAchievementIcon(IntPtr _, string pchName) => SteamEmulator.SteamUserStats.GetAchievementIcon(pchName);
+        public IntPtr GetAchievementDisplayAttribute(IntPtr _, string pchName, string pchKey) => NativeStringCache.ToUtf8Ptr(SteamEmulator.SteamUserStats.GetAchievementDisplayAttribute(pchName, pchKey));
+        public bool IndicateAchievementProgress(IntPtr _, string pchName, uint nCurProgress, uint nMaxProgress) => SteamEmulator.SteamUserStats.IndicateAchievementProgress(pchName, nCurProgress, nMaxProgress);
+        public SteamAPICall_t RequestUserStats(IntPtr _, ulong steamIDUser) => SteamEmulator.SteamUserStats.RequestUserStats(steamIDUser);
+        public bool GetUserStatInt32(IntPtr _, ulong steamIDUser, string pchName, IntPtr pData) => SteamEmulator.SteamUserStats.GetUserStatInt32(steamIDUser, pchName, pData);
+        public bool GetUserStatFloat(IntPtr _, ulong steamIDUser, string pchName, IntPtr pData) => SteamEmulator.SteamUserStats.GetUserStatFloat(steamIDUser, pchName, pData);
+        public bool GetUserAchievement(IntPtr _, ulong steamIDUser, string pchName, IntPtr pbAchieved) => SteamEmulator.SteamUserStats.GetUserAchievement(steamIDUser, pchName, pbAchieved);
+        public bool GetUserAchievementAndUnlockTime(IntPtr _, ulong steamIDUser, string pchName, IntPtr pbAchieved, IntPtr punUnlockTime) => SteamEmulator.SteamUserStats.GetUserAchievementAndUnlockTime(steamIDUser, pchName, pbAchieved, punUnlockTime);
+        public bool ResetAllStats(IntPtr _, bool bAchievementsToo) => SteamEmulator.SteamUserStats.ResetAllStats(bAchievementsToo);
+        public SteamAPICall_t FindOrCreateLeaderboard(IntPtr _, string pchLeaderboardName, ELeaderboardSortMethod eLeaderboardSortMethod, ELeaderboardDisplayType eLeaderboardDisplayType) => SteamEmulator.SteamUserStats.FindOrCreateLeaderboard(pchLeaderboardName, eLeaderboardSortMethod, eLeaderboardDisplayType);
+        public SteamAPICall_t FindLeaderboard(IntPtr _, string pchLeaderboardName) => SteamEmulator.SteamUserStats.FindLeaderboard(pchLeaderboardName);
+        public IntPtr GetLeaderboardName(IntPtr _, ulong hSteamLeaderboard) => NativeStringCache.ToUtf8Ptr(SteamEmulator.SteamUserStats.GetLeaderboardName(hSteamLeaderboard));
+        public int GetLeaderboardEntryCount(IntPtr _, ulong hSteamLeaderboard) => SteamEmulator.SteamUserStats.GetLeaderboardEntryCount(hSteamLeaderboard);
+        public int GetLeaderboardSortMethod(IntPtr _, ulong hSteamLeaderboard) => SteamEmulator.SteamUserStats.GetLeaderboardSortMethod(hSteamLeaderboard);
+        public int GetLeaderboardDisplayType(IntPtr _, ulong hSteamLeaderboard) => SteamEmulator.SteamUserStats.GetLeaderboardDisplayType(hSteamLeaderboard);
+        public SteamAPICall_t DownloadLeaderboardEntries(IntPtr _, ulong hSteamLeaderboard, int eLeaderboardDataRequest, int nRangeStart, int nRangeEnd) => SteamEmulator.SteamUserStats.DownloadLeaderboardEntries(hSteamLeaderboard, eLeaderboardDataRequest, nRangeStart, nRangeEnd);
+        public bool GetDownloadedLeaderboardEntry(IntPtr _, ulong hSteamLeaderboardEntries, int index, IntPtr pLeaderboardEntry, IntPtr pDetails, int cDetailsMax) => SteamEmulator.SteamUserStats.GetDownloadedLeaderboardEntry(hSteamLeaderboardEntries, index, pLeaderboardEntry, pDetails, cDetailsMax);
+        public SteamAPICall_t UploadLeaderboardScore(IntPtr _, ulong hSteamLeaderboard, int eLeaderboardUploadScoreMethod, int nScore, IntPtr pScoreDetails, int cScoreDetailsCount) => SteamEmulator.SteamUserStats.UploadLeaderboardScore(hSteamLeaderboard, eLeaderboardUploadScoreMethod, nScore, pScoreDetails, cScoreDetailsCount);
+        public SteamAPICall_t GetNumberOfCurrentPlayers(IntPtr _) => SteamEmulator.SteamUserStats.GetNumberOfCurrentPlayers();
+    }
+}

--- a/steam_api/Steamworks/Interfaces/SteamUtils/SteamUtils004.cs
+++ b/steam_api/Steamworks/Interfaces/SteamUtils/SteamUtils004.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Runtime.InteropServices;
+
+using SteamAPICall_t = System.UInt64;
+
+namespace SKYNET.Steamworks.Interfaces
+{
+    /// <summary>Legacy ISteamUtils ABI used by the original Left 4 Dead SDK.</summary>
+    [Interface("SteamUtils004")]
+    public class SteamUtils004 : ISteamInterface
+    {
+        public uint GetSecondsSinceAppActive(IntPtr _) => SteamEmulator.SteamUtils.GetSecondsSinceAppActive();
+        public uint GetSecondsSinceComputerActive(IntPtr _) => SteamEmulator.SteamUtils.GetSecondsSinceComputerActive();
+        public int GetConnectedUniverse(IntPtr _) => SteamEmulator.SteamUtils.GetConnectedUniverse();
+        public uint GetServerRealTime(IntPtr _) => SteamEmulator.SteamUtils.GetServerRealTime();
+        public string GetIPCountry(IntPtr _) => SteamEmulator.SteamUtils.GetIPCountry();
+
+        public bool GetImageSize(IntPtr _, int iImage, ref uint pnWidth, ref uint pnHeight) =>
+            SteamEmulator.SteamUtils.GetImageSize(iImage, ref pnWidth, ref pnHeight);
+
+        public bool GetImageRGBA(IntPtr _, int iImage, IntPtr pubDest, int nDestBufferSize) =>
+            SteamEmulator.SteamUtils.GetImageRGBA(iImage, pubDest, nDestBufferSize);
+
+        public bool GetCSERIPPort(IntPtr _, IntPtr unIP, IntPtr usPort) =>
+            SteamEmulator.SteamUtils.GetCSERIPPort(unIP, usPort);
+
+        public byte GetCurrentBatteryPower(IntPtr _) => SteamEmulator.SteamUtils.GetCurrentBatteryPower();
+        public uint GetAppID(IntPtr _) => SteamEmulator.SteamUtils.GetAppID();
+
+        public void SetOverlayNotificationPosition(IntPtr _, int eNotificationPosition) =>
+            SteamEmulator.SteamUtils.SetOverlayNotificationPosition(eNotificationPosition);
+
+        public bool IsAPICallCompleted(IntPtr _, SteamAPICall_t hSteamAPICall, IntPtr pbFailed)
+        {
+            bool failed = false;
+            bool result = SteamEmulator.SteamUtils.IsAPICallCompleted(hSteamAPICall, ref failed);
+            if (pbFailed != IntPtr.Zero)
+            {
+                Marshal.WriteByte(pbFailed, failed ? (byte)1 : (byte)0);
+            }
+            return result;
+        }
+
+        public int GetAPICallFailureReason(IntPtr _, SteamAPICall_t hSteamAPICall) =>
+            SteamEmulator.SteamUtils.GetAPICallFailureReason(hSteamAPICall);
+
+        public bool GetAPICallResult(
+            IntPtr _,
+            SteamAPICall_t hSteamAPICall,
+            IntPtr pCallback,
+            int cubCallback,
+            int iCallbackExpected,
+            IntPtr pbFailed)
+        {
+            bool failed = false;
+            bool result = SteamEmulator.SteamUtils.GetAPICallResult(
+                hSteamAPICall,
+                pCallback,
+                cubCallback,
+                iCallbackExpected,
+                ref failed);
+            if (pbFailed != IntPtr.Zero)
+            {
+                Marshal.WriteByte(pbFailed, failed ? (byte)1 : (byte)0);
+            }
+            return result;
+        }
+
+        public void RunFrame(IntPtr _) => SteamEmulator.SteamUtils.RunFrame();
+        public uint GetIPCCallCount(IntPtr _) => SteamEmulator.SteamUtils.GetIPCCallCount();
+
+        public void SetWarningMessageHook(IntPtr _, IntPtr pFunction) =>
+            SteamEmulator.SteamUtils.SetWarningMessageHook(pFunction);
+
+        public bool IsOverlayEnabled(IntPtr _) => SteamEmulator.SteamUtils.IsOverlayEnabled();
+    }
+}

--- a/steam_api/Steamworks/Interfaces/SteamUtils/SteamUtils009.cs
+++ b/steam_api/Steamworks/Interfaces/SteamUtils/SteamUtils009.cs
@@ -80,9 +80,15 @@ namespace SKYNET.Steamworks.Interfaces
             return SteamEmulator.SteamUtils.GetAPICallFailureReason(hSteamAPICall);
         }
 
-        public bool GetAPICallResult(IntPtr _, SteamAPICall_t hSteamAPICall, IntPtr pCallback, int cubCallback, int iCallbackExpected, ref bool pbFailed)
+        public bool GetAPICallResult(IntPtr _, SteamAPICall_t hSteamAPICall, IntPtr pCallback, int cubCallback, int iCallbackExpected, IntPtr pbFailed)
         {
-            return SteamEmulator.SteamUtils.GetAPICallResult(hSteamAPICall, pCallback, cubCallback, iCallbackExpected, ref pbFailed);
+            bool failed = false;
+            bool result = SteamEmulator.SteamUtils.GetAPICallResult(hSteamAPICall, pCallback, cubCallback, iCallbackExpected, ref failed);
+            if (pbFailed != IntPtr.Zero)
+            {
+                System.Runtime.InteropServices.Marshal.WriteByte(pbFailed, failed ? (byte)1 : (byte)0);
+            }
+            return result;
         }
 
         // Deprecated. Applications should use SteamAPI_RunCallbacks() instead. Game servers do not need to call this function.

--- a/steam_api/Steamworks/Interfaces/SteamUtils/SteamUtils010.cs
+++ b/steam_api/Steamworks/Interfaces/SteamUtils/SteamUtils010.cs
@@ -81,9 +81,15 @@ namespace SKYNET.Steamworks.Interfaces
             return SteamEmulator.SteamUtils.GetAPICallFailureReason(hSteamAPICall);
         }
 
-        public bool GetAPICallResult(IntPtr _, SteamAPICall_t hSteamAPICall, IntPtr pCallback, int cubCallback, int iCallbackExpected, ref bool pbFailed)
+        public bool GetAPICallResult(IntPtr _, SteamAPICall_t hSteamAPICall, IntPtr pCallback, int cubCallback, int iCallbackExpected, IntPtr pbFailed)
         {
-            return SteamEmulator.SteamUtils.GetAPICallResult(hSteamAPICall, pCallback, cubCallback, iCallbackExpected, ref pbFailed);
+            bool failed = false;
+            bool result = SteamEmulator.SteamUtils.GetAPICallResult(hSteamAPICall, pCallback, cubCallback, iCallbackExpected, ref failed);
+            if (pbFailed != IntPtr.Zero)
+            {
+                Marshal.WriteByte(pbFailed, failed ? (byte)1 : (byte)0);
+            }
+            return result;
         }
 
         public void RunFrame(IntPtr _)

--- a/steam_api/steam_api.csproj
+++ b/steam_api/steam_api.csproj
@@ -41,7 +41,7 @@
     <DllExportNamespace>System.Runtime.InteropServices</DllExportNamespace>
     <DllExportDDNSCecil>true</DllExportDDNSCecil>
     <DllExportSkipOnAnyCpu>false</DllExportSkipOnAnyCpu>
-    <DllExportPlatform>Auto</DllExportPlatform>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DllExportOrdinalsBase>1</DllExportOrdinalsBase>
     <DllExportGenExpLib>false</DllExportGenExpLib>
     <DllExportOurILAsm>false</DllExportOurILAsm>
@@ -174,6 +174,7 @@
     <Compile Include="Managers\MemoryManager.cs" />
     <Compile Include="Managers\MusicPlayerManager.cs" />
     <Compile Include="Helpers\NetworkHelper.cs" />
+    <Compile Include="Steamworks\Interfaces\SteamClient\SteamClient009.cs" />
     <Compile Include="Steamworks\Interfaces\SteamClient\SteamClient017.cs" />
     <Compile Include="Steamworks\Interfaces\SteamClient\SteamClient018.cs" />
     <Compile Include="Steamworks\Interfaces\SteamClient\SteamClient019.cs" />
@@ -196,6 +197,7 @@
     <Compile Include="Steamworks\Interfaces\SteamRemotePlay\SteamRemotePlay003.cs" />
     <Compile Include="Steamworks\Interfaces\SteamTimeline\SteamTimeline004.cs" />
     <Compile Include="Steamworks\Interfaces\SteamUnifiedMessages\SteamUnifiedMessages001.cs" />
+    <Compile Include="Steamworks\Interfaces\SteamUser\SteamUser013.cs" />
     <Compile Include="Steamworks\Interfaces\SteamUser\SteamUser020.cs" />
     <Compile Include="Steamworks\Interfaces\SteamUser\SteamUser023.cs" />
     <Compile Include="Steamworks\Types\ISteamMatchmakingServerListResponse.cs" />
@@ -248,9 +250,11 @@
     <Compile Include="Steamworks\Interfaces\SteamAppDisableUpdate001.cs" />
     <Compile Include="Steamworks\Interfaces\SteamClient\SteamClient020.cs" />
     <Compile Include="Steamworks\Interfaces\SteamAppList\SteamAppList001.cs" />
+    <Compile Include="Steamworks\Interfaces\SteamApps\SteamApps003.cs" />
     <Compile Include="Steamworks\Interfaces\SteamApps\SteamApps008.cs" />
     <Compile Include="Steamworks\Interfaces\SteamApps\SteamApps009.cs" />
     <Compile Include="Steamworks\Interfaces\SteamController\SteamController008.cs" />
+    <Compile Include="Steamworks\Interfaces\SteamFriends\SteamFriends005.cs" />
     <Compile Include="Steamworks\Interfaces\SteamFriends\SteamFriends018.cs" />
     <Compile Include="Steamworks\Interfaces\SteamFriends\SteamFriends017.cs" />
     <Compile Include="Steamworks\Interfaces\SteamFriends\SteamFriends015.cs" />
@@ -258,6 +262,7 @@
     <Compile Include="Steamworks\Interfaces\SteamGameServer\SteamGameServer015.cs" />
     <Compile Include="Steamworks\Interfaces\SteamGameServer\SteamGameServer013.cs" />
     <Compile Include="Steamworks\Interfaces\SteamGameServer\SteamGameServer014.cs" />
+    <Compile Include="Steamworks\Interfaces\SteamGameServer\SteamGameServer009.cs" />
     <Compile Include="Steamworks\Interfaces\SteamGameServer\SteamGameServer012.cs" />
     <Compile Include="Steamworks\Interfaces\SteamGameServerStats\SteamGameServerStats001.cs" />
     <Compile Include="Steamworks\Interfaces\SteamGameStats\SteamGameStats001.cs" />
@@ -268,9 +273,11 @@
     <Compile Include="Steamworks\Interfaces\SteamInventory\SteamInventory002.cs" />
     <Compile Include="Steamworks\Interfaces\SteamInventory\SteamInventory003.cs" />
     <Compile Include="Steamworks\Interfaces\SteamMatchGameSearch\SteamMatchGameSearch001.cs" />
+    <Compile Include="Steamworks\Interfaces\SteamMatchmaking\SteamMatchmaking007.cs" />
     <Compile Include="Steamworks\Interfaces\SteamMatchmaking\SteamMatchmaking008.cs" />
     <Compile Include="Steamworks\Interfaces\SteamMatchmaking\SteamMatchmaking009.cs" />
     <Compile Include="Steamworks\Interfaces\SteamMatchmakingServers\SteamMatchmakingServers002.cs" />
+    <Compile Include="Steamworks\Interfaces\SteamMasterServerUpdater\SteamMasterServerUpdater001.cs" />
     <Compile Include="Steamworks\Interfaces\SteamMusic\SteamMusic001.cs" />
     <Compile Include="Steamworks\Interfaces\SteamMusicRemote\SteamMusicRemote001.cs" />
     <Compile Include="Steamworks\Interfaces\SteamNetworkingSocketsSerialized\SteamNetworkingSocketsSerialized003.cs" />
@@ -278,14 +285,17 @@
     <Compile Include="Steamworks\Interfaces\SteamNetworkingSocketsSerialized\SteamNetworkingSocketsSerialized004.cs" />
     <Compile Include="Steamworks\Interfaces\SteamNetworkingSocketsSerialized\SteamNetworkingSocketsSerialized002.cs" />
     <Compile Include="Steamworks\Interfaces\SteamNetworking\SteamNetworking006.cs" />
+    <Compile Include="Steamworks\Interfaces\SteamNetworking\SteamNetworking003.cs" />
     <Compile Include="Steamworks\Interfaces\SteamNetworking\SteamNetworking005.cs" />
     <Compile Include="Steamworks\Interfaces\SteamParentalSettings\SteamParentalSettings001.cs" />
+    <Compile Include="Steamworks\Interfaces\SteamRemoteStorage\SteamRemoteStorage002.cs" />
     <Compile Include="Steamworks\Interfaces\SteamRemoteStorage\SteamRemoteStorage014.cs" />
     <Compile Include="Steamworks\Interfaces\SteamRemoteStorage\SteamRemoteStorage013.cs" />
     <Compile Include="Steamworks\Interfaces\SteamRemoteStorage\SteamRemoteStorage016.cs" />
     <Compile Include="Steamworks\Interfaces\SteamScreenshots\SteamScreenshots003.cs" />
     <Compile Include="Steamworks\Interfaces\SteamUGC\SteamUGC016.cs" />
     <Compile Include="Steamworks\Interfaces\SteamUGC\SteamUGC016Generated.cs" />
+    <Compile Include="Steamworks\Interfaces\SteamUGC\SteamUGC017Generated.cs" />
     <Compile Include="Steamworks\Interfaces\SteamUGC\SteamUGC019.cs" />
     <Compile Include="Steamworks\Interfaces\SteamUGC\SteamUGC019Generated.cs" />
     <Compile Include="Steamworks\Interfaces\SteamUGC\SteamUGC020Generated.cs" />
@@ -298,9 +308,11 @@
     <Compile Include="Steamworks\Interfaces\SteamUGC\SteamUGC014Generated.cs" />
     <Compile Include="Steamworks\Interfaces\SteamUser\SteamUser021.cs" />
     <Compile Include="Steamworks\Interfaces\SteamUser\SteamUser019.cs" />
+    <Compile Include="Steamworks\Interfaces\SteamUserStats\SteamUserStats007.cs" />
     <Compile Include="Steamworks\Interfaces\SteamUserStats\SteamUserStats012.cs" />
     <Compile Include="Steamworks\Interfaces\SteamUserStats\SteamUserStats011Legacy.cs" />
     <Compile Include="Steamworks\Interfaces\SteamUserStats\SteamUserStats012Legacy.cs" />
+    <Compile Include="Steamworks\Interfaces\SteamUtils\SteamUtils004.cs" />
     <Compile Include="Steamworks\Interfaces\SteamUtils\SteamUtils010.cs" />
     <Compile Include="Steamworks\Interfaces\SteamUtils\SteamUtils009.cs" />
     <Compile Include="Steamworks\Interfaces\SteamVideo\SteamVideo002.cs" />
@@ -328,17 +340,17 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ImportGroup Label=".NET DllExport">
-    <Import Project="$(SolutionDir)packages\DllExport\tools\net.r_eg.DllExport.targets" Condition="Exists($([MSBuild]::Escape('$(SolutionDir)packages\DllExport\tools\net.r_eg.DllExport.targets')))" Label="8337224c9ad9e356" />
+    <Import Project="$(SolutionDir)..\packages\DllExport\tools\net.r_eg.DllExport.targets" Condition="Exists($([MSBuild]::Escape('$(SolutionDir)..\packages\DllExport\tools\net.r_eg.DllExport.targets')))" Label="8337224c9ad9e356" />
   </ImportGroup>
   <Target Name="DllExportRestorePkg" BeforeTargets="PrepareForBuild">
     <Error Condition="!Exists('$(SolutionDir)DllExport.bat')" Text="DllExport.bat is not found. Path: '$(SolutionDir)' - https://github.com/3F/DllExport" />
-    <Exec Condition="('$(DllExportModImported)' != 'true' Or !Exists('$(SolutionDir)packages\DllExport\tools\net.r_eg.DllExport.targets')) And Exists('$(SolutionDir)DllExport.bat')" Command=".\DllExport.bat -packages packages -dxp-version actual  -action Restore" WorkingDirectory="$(SolutionDir)" />
-    <MSBuild Condition="'$(DllExportModImported)' != 'true'" Projects="$(SolutionDir)packages\DllExport\tools\net.r_eg.DllExport.targets" Targets="DllExportMetaXBaseTarget" Properties="TargetFramework=$(TargetFramework)">
+    <Exec Condition="('$(DllExportModImported)' != 'true' Or !Exists('$(SolutionDir)..\packages\DllExport\tools\net.r_eg.DllExport.targets')) And Exists('$(SolutionDir)DllExport.bat')" Command=".\DllExport.bat -packages packages -dxp-version actual  -action Restore" WorkingDirectory="$(SolutionDir)" />
+    <MSBuild Condition="'$(DllExportModImported)' != 'true'" Projects="$(SolutionDir)..\packages\DllExport\tools\net.r_eg.DllExport.targets" Targets="DllExportMetaXBaseTarget" Properties="TargetFramework=$(TargetFramework)">
       <Output TaskParameter="TargetOutputs" PropertyName="DllExportMetaXBase" />
     </MSBuild>
     <ItemGroup>
       <Reference Include="DllExport, PublicKeyToken=8337224c9ad9e356">
-        <HintPath>$(SolutionDir)packages\DllExport\gcache\$(DllExportMetaXBase)\$(DllExportNamespace)\$(DllExportMetaLibName)</HintPath>
+        <HintPath>$(SolutionDir)..\packages\DllExport\gcache\$(DllExportMetaXBase)\$(DllExportNamespace)\$(DllExportMetaLibName)</HintPath>
         <Private>False</Private>
         <SpecificVersion>False</SpecificVersion>
       </Reference>

--- a/steam_api/steam_api.sln
+++ b/steam_api/steam_api.sln
@@ -1,8 +1,8 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.5.2.0
+# Visual Studio Version 18
+VisualStudioVersion = 18.9.12105.275 stable
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "steam_api", "steam_api.csproj", "{95D4311C-50B7-C700-F565-202B2F945B01}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "steam_api", "steam_api.csproj", "{F296C00A-53B4-4A0D-977B-F1946B1ACCE2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -10,10 +10,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{95D4311C-50B7-C700-F565-202B2F945B01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{95D4311C-50B7-C700-F565-202B2F945B01}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{95D4311C-50B7-C700-F565-202B2F945B01}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{95D4311C-50B7-C700-F565-202B2F945B01}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F296C00A-53B4-4A0D-977B-F1946B1ACCE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F296C00A-53B4-4A0D-977B-F1946B1ACCE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F296C00A-53B4-4A0D-977B-F1946B1ACCE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F296C00A-53B4-4A0D-977B-F1946B1ACCE2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

This PR extends compatibility with older x86 Steamworks games while preserving the existing x64 launch path.

### Changes

- Detect the target executable architecture directly from its PE header and select the matching x86/x64 payload.
- Add a small x86 injector helper for 32-bit games that dynamically load `steam_api.dll`.
- Launch dynamic consumers suspended, inject the matching payload, and resume only after successful loading.
- Redirect direct/static Steam API imports to the prepared payload before the initial game thread starts.
- Add legacy Steamworks interfaces, callback handling, lobby support, and connection-oriented networking used by older Source-era games.
- Keep the active payload shadow plus up to three previous versions per architecture to prevent unbounded Temp directory growth.

## Tested

- `SKYNET server` Release build.
- `SKYNET Steam Client` Release build, including the x86 helper.
- `steam_api` x86 and x64 Release builds.
- AppID **320 (x86):** successful launch and multiplayer operation over LAN.
- AppID **500 (x86):** successful launch, lobby creation/joining, and LAN multiplayer flow.
- AppID **4000 x86_64 branch and x86** successful launch and multiplayer operation over LAN.
- Tested between separate PCs on the same network.

## Injector helper design

The launcher normally runs as a 64-bit process on 64-bit Windows. Reusing its native `LoadLibraryW` address inside a WOW64 x86 target is unreliable, so the current implementation delegates dynamic x86 injection to a small 32-bit helper.

The helper is packaged under `helpers/x86` and is only used when an x86 game requires dynamic injection. The normal x64 path and static-import redirection remain inside the main launcher.

Would you prefer to keep this helper as a separate architecture bridge, or would you rather reshape/integrate the injection approach differently in the main project?